### PR TITLE
Fixing VCS dumping

### DIFF
--- a/cosim/black-parrot-example/ps.cpp
+++ b/cosim/black-parrot-example/ps.cpp
@@ -128,6 +128,7 @@ extern "C" void cosim_main(char *argstr) {
         "No nbf file specified, sleeping for 2^31 seconds (this will hold "
         "onto allocated DRAM)\n");
     sleep(1 << 31);
+    delete zpl;
     exit(0);
   }
 
@@ -323,6 +324,7 @@ void nbf_load(bp_zynq_pl *zpl, char *nbf_filename) {
 
   if (!nbf_file.is_open()) {
     bsg_pr_err("ps.cpp: error opening nbf file.\n");
+    delete zpl;
     exit(-1);
   }
 

--- a/cosim/black-parrot-example/v/top.v
+++ b/cosim/black-parrot-example/v/top.v
@@ -401,8 +401,9 @@ module top
        if ($test$plusargs("bsg_trace") != 0)
          begin
            $display("[%0t] Tracing to vcdplus.vpd...\n", $time);
-           $dumpfile("vcdplus.vpd");
-           $dumpvars();
+           $vcdplusfile("vcdplus.vpd");
+           $vcdpluson();
+           $vcdplusautoflushon();
          end
        if ($test$plusargs("c_args") != 0)
          begin

--- a/cosim/double-shell-example/v/top.v
+++ b/cosim/double-shell-example/v/top.v
@@ -312,8 +312,9 @@ module top #
        if ($test$plusargs("bsg_trace") != 0)
          begin
            $display("[%0t] Tracing to vcdplus.vpd...\n", $time);
-           $dumpfile("vcdplus.vpd");
-           $dumpvars();
+           $vcdplusfile("vcdplus.vpd");
+           $vcdpluson();
+           $vcdplusautoflushon();
          end
        if ($test$plusargs("c_args") != 0)
          begin

--- a/cosim/mk/Makefile.vcs
+++ b/cosim/mk/Makefile.vcs
@@ -12,8 +12,6 @@ VCS_OPTS += -diag timescale
 VCS_OPTS += -f flist.vcs
 VCS_OPTS += -top $(TOP_MODULE)
 VCS_OPTS += -debug_pp
-VCS_OPTS += +vcs+vcdpluson
-VCS_OPTS += +vcs+vcdplusautoflushon
 VCS_OPTS += +incdir+$(COSIM_DIR)/include/vcs
 
 CFLAGS += -DVCS
@@ -33,7 +31,7 @@ simv: $(HOST_PROGRAM) $(FLIST)
 	$(VCS) $(VCS_OPTS) -CFLAGS "$(CFLAGS)" -CFLAGS "$(CINCLUDES)" -o $@ $<
 
 run: simv
-	$< $(SIM_ARGS) $(TRACE)
+	./$< $(SIM_ARGS) $(TRACE)
 
 clean:
 	-rm -rf csrc/

--- a/cosim/shell-example/v/top.v
+++ b/cosim/shell-example/v/top.v
@@ -201,8 +201,9 @@ module top #
        if ($test$plusargs("bsg_trace") != 0)
          begin
            $display("[%0t] Tracing to vcdplus.vpd...\n", $time);
-           $dumpfile("vcdplus.vpd");
-           $dumpvars();
+           $vcdplusfile("vcdplus.vpd");
+           $vcdpluson();
+           $vcdplusautoflushon();
          end
        if ($test$plusargs("c_args") != 0)
          begin

--- a/cosim/simple-example/v/top.v
+++ b/cosim/simple-example/v/top.v
@@ -141,8 +141,9 @@
        if ($test$plusargs("bsg_trace") != 0)
          begin
            $display("[%0t] Tracing to vcdplus.vpd...\n", $time);
-           $dumpfile("vcdplus.vpd");
-           $dumpvars();
+           $vcdplusfile("vcdplus.vpd");
+           $vcdpluson();
+           $vcdplusautoflushon();
          end
        if ($test$plusargs("c_args") != 0)
          begin


### PR DESCRIPTION
This PR fixes VCS dumping for zynq-parrot. Otherwise, the VPD file comes out corrupted and can't be opened by DVE