### PR TITLE
Add RT clk to zynq

### DIFF
--- a/cosim/black-parrot-example/v/top.v
+++ b/cosim/black-parrot-example/v/top.v
@@ -20,6 +20,7 @@ module top
 `ifdef FPGA
     input wire                                   aclk
     ,input wire                                  aresetn
+    ,input wire                                  rt_clk
 
     ,input wire [C_S00_AXI_ADDR_WIDTH-1 : 0]     s00_axi_awaddr
     ,input wire [2 : 0]                          s00_axi_awprot
@@ -129,6 +130,13 @@ module top
     assign {s00_axi_aresetn, s01_axi_aresetn, m00_axi_aresetn, m01_axi_aresetn} = {4{aresetn}};
 `else
     );
+
+    localparam rt_clk_period_lp = 2500000;
+    logic rt_clk;
+    bsg_nonsynth_clock_gen
+     #(.cycle_time_p(`RT_CLK_FREQ))
+     rt_clk_gen
+      (.o(rt_clk));
 
     logic s00_axi_aclk, s00_axi_aresetn;
     logic [C_S00_AXI_ADDR_WIDTH-1:0] s00_axi_awaddr;
@@ -365,7 +373,9 @@ module top
       ,.C_M01_AXI_ADDR_WIDTH(C_M01_AXI_ADDR_WIDTH)
       )
      top_fpga_inst
-     (.s00_axi_aclk    (s00_axi_aclk)
+     (.rt_clk          (rt_clk)
+
+      ,.s00_axi_aclk   (s00_axi_aclk)
       ,.s00_axi_aresetn(s00_axi_aresetn)
       ,.s00_axi_awaddr (s00_axi_awaddr)
       ,.s00_axi_awprot (s00_axi_awprot)

--- a/cosim/black-parrot-example/v/top_zynq.sv
+++ b/cosim/black-parrot-example/v/top_zynq.sv
@@ -30,8 +30,10 @@ module top_zynq
    , parameter integer C_M01_AXI_DATA_WIDTH   = 32
    , parameter integer C_M01_AXI_ADDR_WIDTH   = 32
    )
-  (// Ports of Axi Slave Bus Interface S00_AXI
-   input wire                                    s00_axi_aclk
+  (input wire                                    rt_clk_i
+   
+   // Ports of Axi Slave Bus Interface S00_AXI
+   , input wire                                  s00_axi_aclk
    , input wire                                  s00_axi_aresetn
    , input wire [C_S00_AXI_ADDR_WIDTH-1 : 0]     s00_axi_awaddr
    , input wire [2 : 0]                          s00_axi_awprot
@@ -512,6 +514,7 @@ module top_zynq
    blackparrot
      (.clk_i(s01_axi_aclk)
       ,.reset_i(bp_reset_li)
+      ,.rt_clk_i(rt_clk_i)
 
       // these are reads/write from BlackParrot
       ,.m_axil_awaddr_o (bp_axi_awaddr)

--- a/cosim/black-parrot-example/v/top_zynq.sv
+++ b/cosim/black-parrot-example/v/top_zynq.sv
@@ -30,7 +30,7 @@ module top_zynq
    , parameter integer C_M01_AXI_DATA_WIDTH   = 32
    , parameter integer C_M01_AXI_ADDR_WIDTH   = 32
    )
-  (input wire                                    rt_clk_i
+  (input wire                                    rt_clk
    
    // Ports of Axi Slave Bus Interface S00_AXI
    , input wire                                  s00_axi_aclk
@@ -514,7 +514,7 @@ module top_zynq
    blackparrot
      (.clk_i(s01_axi_aclk)
       ,.reset_i(bp_reset_li)
-      ,.rt_clk_i(rt_clk_i)
+      ,.rt_clk_i(rt_clk)
 
       // these are reads/write from BlackParrot
       ,.m_axil_awaddr_o (bp_axi_awaddr)

--- a/cosim/black-parrot-example/vivado/vivado-create-block.pynqz2.2019.1.tcl
+++ b/cosim/black-parrot-example/vivado/vivado-create-block.pynqz2.2019.1.tcl
@@ -8,7 +8,10 @@ update_compile_order -fileset sources_1
 startgroup
 create_bd_cell -type ip -vlnv xilinx.com:ip:processing_system7:5.5 processing_system7_0
 set_property -dict [list CONFIG.PCW_USE_M_AXI_GP1 {1}] [get_bd_cells processing_system7_0]
+set_property -dict [list CONFIG.PCW_EN_CLK0_PORT {1}] [get_bd_cells processing_system7_0]
 set_property -dict [list CONFIG.PCW_FPGA0_PERIPHERAL_FREQMHZ {20}] [get_bd_cells processing_system7_0]
+set_property -dict [list CONFIG.PCW_EN_CLK1_PORT {1}] [get_bd_cells processing_system7_0]
+set_property -dict [list CONFIG.PCW_FPGA1_PERIPHERAL_FREQMHZ {0.4}] [get_bd_cells processing_system7_0]
 set_property -dict [list CONFIG.PCW_USE_S_AXI_HP0 {1}] [get_bd_cells processing_system7_0]
 endgroup
 apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {make_external "FIXED_IO, DDR" Master "Disable" Slave "Disable" }  [get_bd_cells processing_system7_0]
@@ -29,6 +32,8 @@ endgroup
 
 startgroup
 create_bd_cell -type ip -vlnv user.org:user:top:1.0 top_0
+set_property -dict [list CONFIG.FREQ_HZ [get_property CONFIG.FREQ_HZ [get_bd_pins /processing_system7_0/FCLK_CLK0]]] [get_bd_pins top_0/aclk]
+set_property -dict [list CONFIG.FREQ_HZ [get_property CONFIG.FREQ_HZ [get_bd_pins /processing_system7_0/FCLK_CLK1]]] [get_bd_pins top_0/rt_clk]
 endgroup
 startgroup
 create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_0
@@ -61,6 +66,7 @@ apply_bd_automation -rule xilinx.com:bd_rule:board -config { Manual_Source {Auto
 endgroup
 
 connect_bd_net [get_bd_pins /axi_bram_ctrl_0/s_axi_aclk] [get_bd_pins processing_system7_0/FCLK_CLK0]
+connect_bd_net [get_bd_pins top_0/rt_clk] [get_bd_pins processing_system7_0/FCLK_CLK1]
 
 create_bd_addr_seg -range 0x00002000 -offset 0x10000000 [get_bd_addr_spaces top_0/m01_axi] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] SEG_axi_bram_ctrl_0_Mem0
 assign_bd_address

--- a/cosim/black-parrot-example/vivado/vivado-create-block.pynqz2.2022.1.tcl
+++ b/cosim/black-parrot-example/vivado/vivado-create-block.pynqz2.2022.1.tcl
@@ -8,7 +8,10 @@ update_compile_order -fileset sources_1
 startgroup
 create_bd_cell -type ip -vlnv xilinx.com:ip:processing_system7:5.5 processing_system7_0
 set_property -dict [list CONFIG.PCW_USE_M_AXI_GP1 {1}] [get_bd_cells processing_system7_0]
+set_property -dict [list CONFIG.PCW_EN_CLK0_PORT {1}] [get_bd_cells processing_system7_0]
 set_property -dict [list CONFIG.PCW_FPGA0_PERIPHERAL_FREQMHZ {20}] [get_bd_cells processing_system7_0]
+set_property -dict [list CONFIG.PCW_EN_CLK1_PORT {1}] [get_bd_cells processing_system7_0]
+set_property -dict [list CONFIG.PCW_FPGA1_PERIPHERAL_FREQMHZ {0.4}] [get_bd_cells processing_system7_0]
 set_property -dict [list CONFIG.PCW_USE_S_AXI_HP0 {1}] [get_bd_cells processing_system7_0]
 endgroup
 apply_bd_automation -rule xilinx.com:bd_rule:processing_system7 -config {make_external "FIXED_IO, DDR" Master "Disable" Slave "Disable" }  [get_bd_cells processing_system7_0]
@@ -29,6 +32,8 @@ endgroup
 
 startgroup
 create_bd_cell -type ip -vlnv user.org:user:top:1.0 top_0
+set_property -dict [list CONFIG.FREQ_HZ [get_property CONFIG.FREQ_HZ [get_bd_pins /processing_system7_0/FCLK_CLK0]]] [get_bd_pins top_0/aclk]
+set_property -dict [list CONFIG.FREQ_HZ [get_property CONFIG.FREQ_HZ [get_bd_pins /processing_system7_0/FCLK_CLK1]]] [get_bd_pins top_0/rt_clk]
 endgroup
 startgroup
 create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_0
@@ -61,6 +66,7 @@ apply_bd_automation -rule xilinx.com:bd_rule:board -config { Manual_Source {Auto
 endgroup
 
 connect_bd_net [get_bd_pins /axi_bram_ctrl_0/s_axi_aclk] [get_bd_pins processing_system7_0/FCLK_CLK0]
+connect_bd_net [get_bd_pins top_0/rt_clk] [get_bd_pins processing_system7_0/FCLK_CLK1]
 
 create_bd_addr_seg -range 0x00002000 -offset 0x10000000 [get_bd_addr_spaces top_0/m01_axi] [get_bd_addr_segs axi_bram_ctrl_0/S_AXI/Mem0] SEG_axi_bram_ctrl_0_Mem0
 assign_bd_address

--- a/cosim/black-parrot-example/vivado/vivado-create-block.ultra96v2.2020.1.tcl
+++ b/cosim/black-parrot-example/vivado/vivado-create-block.ultra96v2.2020.1.tcl
@@ -11,11 +11,12 @@ update_ip_catalog
 
 startgroup
 create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:3.3 zynq_ultra_ps_e_0
-set_property -dict [list CONFIG.PSU__CRL_APB__PL0_REF_CTRL__FREQMHZ {50}] [get_bd_cells zynq_ultra_ps_e_0]
+set_property -dict [list CONFIG.PSU__FPGA_PL0_ENABLE {1}  CONFIG.PSU__CRL_APB__PL0_REF_CTRL__FREQMHZ {50}] [get_bd_cells zynq_ultra_ps_e_0]
 set_property -dict [list CONFIG.PSU__USE__M_AXI_GP0 {1} CONFIG.PSU__MAXIGP0__DATA_WIDTH {32}] [get_bd_cells zynq_ultra_ps_e_0]
 set_property -dict [list CONFIG.PSU__USE__M_AXI_GP1 {1} CONFIG.PSU__MAXIGP1__DATA_WIDTH {32}] [get_bd_cells zynq_ultra_ps_e_0]
 set_property -dict [list CONFIG.PSU__USE__S_AXI_GP3 {1} CONFIG.PSU__SAXIGP3__DATA_WIDTH {64}] [get_bd_cells zynq_ultra_ps_e_0]
 set_property -dict [list CONFIG.PSU__USE__M_AXI_GP2 {0}] [get_bd_cells zynq_ultra_ps_e_0]
+set_property -dict [list CONFIG.PSU__FPGA_PL1_ENABLE {1} CONFIG.PSU__CRL_APB__PL1_REF_CTRL__FREQMHZ {0.4}] [get_bd_cells zynq_ultra_ps_e_0]
 endgroup
 
 startgroup
@@ -30,6 +31,8 @@ apply_bd_automation -rule xilinx.com:bd_rule:bram_cntlr -config {BRAM "Auto"} [g
 endgroup
 
 create_bd_cell -type ip -vlnv user.org:user:top:1.0 top_0
+set_property -dict [list CONFIG.FREQ_HZ [get_property CONFIG.FREQ_HZ [get_bd_pins /zynq_ultra_ps_e_0/pl_clk0]]] [get_bd_pins top_0/aclk]
+set_property -dict [list CONFIG.FREQ_HZ [get_property CONFIG.FREQ_HZ [get_bd_pins /zynq_ultra_ps_e_0/pl_clk1]]] [get_bd_pins top_0/rt_clk]
 
 create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_0
 set_property -dict [list CONFIG.NUM_SI {1}] [get_bd_cells smartconnect_0]
@@ -50,6 +53,7 @@ connect_bd_net [get_bd_pins proc_sys_reset_0/peripheral_aresetn] [get_bd_pins sm
 connect_bd_net [get_bd_pins proc_sys_reset_0/peripheral_aresetn] [get_bd_pins axi_bram_ctrl_0/s_axi_aresetn]
 
 connect_bd_net [get_bd_pins zynq_ultra_ps_e_0/pl_clk0] [get_bd_pins top_0/aclk]
+connect_bd_net [get_bd_pins zynq_ultra_ps_e_0/pl_clk1] [get_bd_pins top_0/rt_clk]
 connect_bd_net [get_bd_pins zynq_ultra_ps_e_0/pl_clk0] [get_bd_pins smartconnect_0/aclk]
 connect_bd_net [get_bd_pins zynq_ultra_ps_e_0/pl_clk0] [get_bd_pins smartconnect_1/aclk]
 connect_bd_net [get_bd_pins zynq_ultra_ps_e_0/pl_clk0] [get_bd_pins smartconnect_2/aclk]
@@ -92,5 +96,3 @@ wait_on_run impl_1
 }
 
 puts "Completed. Type start_gui to enter vivado GUI; quit to exit"
-
-exit


### PR DESCRIPTION
This PR adds an RTC to zynq in verilog. The wire needs to be hooked up in IPI to be of use, but the RTL is designed so that dangling RTC will not cause X-propagation