### PR TITLE
Fix waveform dump

### DIFF
--- a/cosim/black-parrot-example/ps.cpp
+++ b/cosim/black-parrot-example/ps.cpp
@@ -371,9 +371,12 @@ extern "C" void cosim_main(char *argstr) {
 #endif
 
   zpl->done();
-
   delete zpl;
+#ifdef VCS
+  return;
+#else
   exit(EXIT_SUCCESS);
+#endif
 }
 
 std::uint32_t rotl(std::uint32_t v, std::int32_t shift) {

--- a/cosim/black-parrot-example/v/top.v
+++ b/cosim/black-parrot-example/v/top.v
@@ -487,17 +487,7 @@ module top
       ,.m01_axi_rready (m01_axi_rready)
       );
 
-`ifdef VERILATOR
-   initial
-     begin
-       if ($test$plusargs("bsg_trace") != 0)
-         begin
-           $display("[%0t] Tracing to trace.fst...\n", $time);
-           $dumpfile("trace.fst");
-           $dumpvars();
-         end
-     end
-`elsif VCS
+`ifdef VCS
    import "DPI-C" context task cosim_main(string c_args);
    string c_args;
    initial
@@ -514,6 +504,7 @@ module top
            $value$plusargs("c_args=%s", c_args);
          end
        cosim_main(c_args);
+       $finish;
      end
 
    // Evaluate the simulation, until the next clk_i positive edge.

--- a/cosim/include/vcs/bp_zynq_pl.h
+++ b/cosim/include/vcs/bp_zynq_pl.h
@@ -52,14 +52,13 @@ public:
 };
 
 class bp_zynq_pl {
-
-  static std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > axi_gp0;
-  static std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
-  static std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
+public:
+  std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > axi_gp0;
+  std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
+  std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
 
   static std::unique_ptr<zynq_scratchpad> scratchpad;
 
-public:
   // Move the simulation forward to the next DPI event
   static void tick(void) { bsg_dpi_next(); }
 
@@ -166,10 +165,6 @@ public:
     }
   }
 };
-
-std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > bp_zynq_pl::axi_gp0;
-std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > bp_zynq_pl::axi_gp1;
-std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > bp_zynq_pl::axi_hp0;
 
 std::unique_ptr<zynq_scratchpad> bp_zynq_pl::scratchpad;
 

--- a/cosim/include/vcs/bp_zynq_pl.h
+++ b/cosim/include/vcs/bp_zynq_pl.h
@@ -57,7 +57,7 @@ public:
   std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
   std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
 
-  static std::unique_ptr<zynq_scratchpad> scratchpad;
+  std::unique_ptr<zynq_scratchpad> scratchpad;
 
   // Move the simulation forward to the next DPI event
   static void tick(void) { bsg_dpi_next(); }
@@ -165,7 +165,5 @@ public:
     }
   }
 };
-
-std::unique_ptr<zynq_scratchpad> bp_zynq_pl::scratchpad;
 
 #endif

--- a/cosim/include/verilator/bp_zynq_pl.h
+++ b/cosim/include/verilator/bp_zynq_pl.h
@@ -57,7 +57,7 @@ public:
   std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
   std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
 
-  static std::unique_ptr<zynq_scratchpad> scratchpad;
+  std::unique_ptr<zynq_scratchpad> scratchpad;
 
   // Each bsg_timekeeper::next() moves to the next clock edge
   //   so we need 2 to perform one full clock cycle.
@@ -197,7 +197,5 @@ public:
 
 Vtop *bp_zynq_pl::tb;
 VerilatedFstC *bp_zynq_pl::wf;
-
-std::unique_ptr<zynq_scratchpad> bp_zynq_pl::scratchpad;
 
 #endif

--- a/cosim/include/verilator/bp_zynq_pl.h
+++ b/cosim/include/verilator/bp_zynq_pl.h
@@ -15,6 +15,8 @@
 #include "bsg_nonsynth_dpi_clock_gen.hpp"
 #include "bsg_nonsynth_dpi_gpio.hpp"
 #include "zynq_headers.h"
+#include "verilated_fst_c.h"
+#include "verilated_cov.h"
 
 using namespace std;
 using namespace bsg_nonsynth_dpi;
@@ -48,14 +50,15 @@ public:
 
 class bp_zynq_pl {
   static Vtop *tb;
+  static VerilatedFstC *wf;
 
-  static std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > axi_gp0;
-  static std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
-  static std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
+public:
+  std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > axi_gp0;
+  std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
+  std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
 
   static std::unique_ptr<zynq_scratchpad> scratchpad;
 
-public:
   // Each bsg_timekeeper::next() moves to the next clock edge
   //   so we need 2 to perform one full clock cycle.
   // If your design does not evaluate things on negedge, you could omit
@@ -63,12 +66,17 @@ public:
   //   at the least.
   static void tick(void) {
     tb->eval();
+    wf->dump(sc_time_stamp());
     bsg_timekeeper::next();
     tb->eval();
+    wf->dump(sc_time_stamp());
     bsg_timekeeper::next();
   }
 
-  static void done(void) { printf("bp_zynq_pl: done() called, exiting\n"); }
+  static void done(void) {
+    printf("bp_zynq_pl: done() called, exiting\n");
+    wf->close();
+  }
 
   bp_zynq_pl(int argc, char *argv[]) {
     // Initialize Verilators variables
@@ -78,6 +86,10 @@ public:
     Verilated::traceEverOn(true);
 
     tb = new Vtop();
+
+    wf = new VerilatedFstC;
+    tb->trace(wf, 10);
+    wf->open("trace.fst");
 
     // Tick once to register clock generators
     tb->eval();
@@ -184,9 +196,7 @@ public:
 };
 
 Vtop *bp_zynq_pl::tb;
-std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > bp_zynq_pl::axi_gp0;
-std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > bp_zynq_pl::axi_gp1;
-std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > bp_zynq_pl::axi_hp0;
+VerilatedFstC *bp_zynq_pl::wf;
 
 std::unique_ptr<zynq_scratchpad> bp_zynq_pl::scratchpad;
 


### PR DESCRIPTION
In the current version, neither VCS nor Verilator simulation dumps complete waveform after finishing a simulation (sometimes I even get corrupted waveform files that cannot be open). One simple way to reproduce this issue is to run "hello world" nbf. In my testing, both VCS and Verilator happen to be able to generate "viewable" waveform. However neither of them is complete. The waveform from VCS doesn't even include the time period where the "hello world" string is being transmitted.

This PR can fix this problem, and the changes should only affect simulation. However I am not sure if I am on the right track:

* What changes did I make to VCS part:
Why can't we always get complete waveform from VCS? My best guess is because once the ./simv program finishes executing exit(0) at the end of a simulation run, simv will just exit right away without switching back to the VCS runtime, and therefore VCS will not have the chance to dump the rest of the waveform data.

My solution to that is to make VCS return from ps.cpp back to verilog code once sim is done, and then call "$finish" there to let VCS terminates itself properly. This change alone is not enough, we would also need to make all axilm, axils objects (axi_gp0, axi_gp1, axi_hp0) non-static, as otherwise we would get fatal errors from [bsg_nonsynth_dpi_gpio.v](https://github.com/bespoke-silicon-group/basejump_stl/blob/master/bsg_test/bsg_nonsynth_dpi_gpio.v#L64). The destructors of all the static objects in c++ would be called after main() is returned; also bsg_dpi_fini() is called when axilm/axils destructor is called. Therefore we have the following erroneous call sequence: final block -> exit of main() -> bsg_dpi_fini().

I have tried using $dumpflush to force dump before calling exit(0) in ps.cpp, but with no luck. We could also try calling destructors of static objects explicitly, but not sure if it's safe to do so.

* What changes did I make to Verilator part:
I think Verilator has the similar issue as VCS. My solution is to explicitly dump data points at every clock tick, and explicitly close the waveform file to flush when sim is done.