### PR TITLE
Separating basejump from blackparrot

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "software/import/black-parrot-sdk"]
 	path = software/import/black-parrot-sdk
 	url = https://github.com/black-parrot-sdk/black-parrot-sdk
+[submodule "cosim/import/basejump_stl"]
+	path = cosim/import/basejump_stl
+	url = https://github.com/bespoke-silicon-group/basejump_stl

--- a/Makefile.common
+++ b/Makefile.common
@@ -11,16 +11,18 @@ export COSIM_PY_DIR          ?= $(COSIM_DIR)/py
 export COSIM_TCL_DIR         ?= $(COSIM_DIR)/tcl
 export COSIM_IMPORT_DIR      ?= $(COSIM_DIR)/import
 
-export BLACKPARROT_DIR       ?= $(COSIM_DIR)/import/black-parrot
-export BLACKPARROT_TOOLS_DIR ?= $(COSIM_DIR)/import/black-parrot-tools
-export BLACKPARROT_SUB_DIR   ?= $(COSIM_DIR)/import/black-parrot-subsystems
+export BASEJUMP_STL_DIR      ?= $(COSIM_IMPORT_DIR)/basejump_stl
+
+export BLACKPARROT_DIR       ?= $(COSIM_IMPORT_DIR)/black-parrot
+export BLACKPARROT_TOOLS_DIR ?= $(COSIM_IMPORT_DIR)/black-parrot-tools
+export BLACKPARROT_SUB_DIR   ?= $(COSIM_IMPORT_DIR)/black-parrot-subsystems
 export BP_FE_DIR             ?= $(BLACKPARROT_DIR)/bp_fe
 export BP_COMMON_DIR         ?= $(BLACKPARROT_DIR)/bp_common
 export BP_BE_DIR             ?= $(BLACKPARROT_DIR)/bp_be
 export BP_ME_DIR             ?= $(BLACKPARROT_DIR)/bp_me
 export BP_TOP_DIR            ?= $(BLACKPARROT_DIR)/bp_top
 export BP_EXTERNAL_DIR       ?= $(BLACKPARROT_DIR)/external
-export BASEJUMP_STL_DIR      ?= $(BP_EXTERNAL_DIR)/basejump_stl
+export BP_BASEJUMP_STL_DIR   ?= $(BP_EXTERNAL_DIR)/basejump_stl
 export HARDFLOAT_DIR         ?= $(BP_EXTERNAL_DIR)/HardFloat
 # Override to zynq-parrot version
 export BP_TOOLS_DIR          ?= $(BLACKPARROT_TOOLS_DIR)

--- a/cosim/black-parrot-example/.gitignore
+++ b/cosim/black-parrot-example/.gitignore
@@ -1,3 +1,4 @@
 blackparrot_ip_proj*
 blackparrot_bd_*
 flist.vcs
+flist.blackparrot.vcs

--- a/cosim/black-parrot-example/vcs/Makefile
+++ b/cosim/black-parrot-example/vcs/Makefile
@@ -23,8 +23,14 @@ CFLAGS += $(INCLUDES) $(SKIP_DRAM)
 # Modify base flist
 #############################
 BASE_FLIST ?= $(abspath ../flist.vcs)
+BP_FLIST   ?= $(abspath flist.blackparrot.vcs)
 FLIST      ?= $(abspath flist.vcs)
-$(FLIST): $(BLACKPARROT_DIR)/bp_top/syn/flist.vcs $(BASE_FLIST)
+
+$(BP_FLIST): $(BLACKPARROT_DIR)/bp_top/syn/flist.vcs
+	cp $^ $@
+	sed -i "s/BASEJUMP_STL_DIR/BP_BASEJUMP_STL_DIR/g" $@
+
+$(FLIST): $(BP_FLIST) $(BASE_FLIST)
 	cat $^ | envsubst > $@
 	echo "+incdir+$(CURR_SRC_DIR)" >> $@
 	echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_clock_gen.v" >> $@

--- a/cosim/mk/Makefile.vcs
+++ b/cosim/mk/Makefile.vcs
@@ -42,7 +42,7 @@ clean:
 	-rm -rf csrc/
 	-rm -rf ucli.key
 	-rm -rf vc_hdrs.h
-	-rm -rf flist.vcs
+	-rm -rf flist*.vcs
 	-rm -rf simv* vcdplus.vpd
 	-rm -rf build.log
 	-rm -rf run.log

--- a/cosim/mk/Makefile.verilator
+++ b/cosim/mk/Makefile.verilator
@@ -33,7 +33,7 @@ obj_dir/V$(TOP_MODULE): $(HOST_PROGRAM) $(FLIST)
 		2>&1 | tee -i $(BUILD_LOG)
 
 clean:
-	-rm -rf flist.vcs
+	-rm -rf flist*.vcs
 	-rm -rf obj_dir/ *~ trace.fst
 	-rm -rf build.log
 	-rm -rf run.log


### PR DESCRIPTION
This PR includes a version of BaseJump STL in zynq-parrot. This version may be out of sync with BlackParrot, which is useful for widgets which are added to the library but have not been updated in BlackParrot yet.

There is a danger of using different versions of components in zynq-parrot and BlackParrot -- however, this should be a rare case