### PR TITLE
Adding Dromajo cosimulation to zynq-parrot

### DIFF
--- a/cosim/black-parrot-example/.gitignore
+++ b/cosim/black-parrot-example/.gitignore
@@ -2,3 +2,5 @@ blackparrot_ip_proj*
 blackparrot_bd_*
 flist.vcs
 flist.blackparrot.vcs
+prog.elf
+commit_*.trace

--- a/cosim/black-parrot-example/v/top.v
+++ b/cosim/black-parrot-example/v/top.v
@@ -487,6 +487,71 @@ module top
       ,.m01_axi_rready (m01_axi_rready)
       );
 
+`ifdef DROMAJO_COSIM
+  logic cosim_clk;
+  bsg_nonsynth_clock_gen
+   #(.cycle_time_p(1000))
+   cosim_clk_gen
+    (.o(cosim_clk));
+
+  logic cosim_reset;
+  bsg_nonsynth_reset_gen
+   #(.num_clocks_p(1)
+     ,.reset_cycles_lo_p(0)
+     ,.reset_cycles_hi_p(10)
+     )
+   cosim_reset_gen
+    (.clk_i(cosim_clk)
+     ,.async_reset_o(cosim_reset)
+     );
+
+   bind bp_be_top
+     bp_nonsynth_cosim
+      #(.bp_params_p(bp_params_p))
+      cosim
+       (.clk_i(clk_i)
+        ,.reset_i(reset_i)
+        ,.freeze_i(calculator.pipe_sys.csr.cfg_bus_cast_i.freeze)
+
+        // We hardcode these for now, integrate more cosim features later
+        ,.num_core_i(1'b1)
+        ,.cosim_en_i(1'b1)
+        ,.amo_en_i(1'b1)
+        ,.trace_en_i('0)
+        ,.checkpoint_i('0)
+        ,.mhartid_i('0)
+        ,.config_file_i('0)
+        ,.instr_cap_i(0)
+        ,.memsize_i(256)
+
+        ,.decode_i(calculator.reservation_n.decode)
+
+        ,.is_debug_mode_i(calculator.pipe_sys.csr.is_debug_mode)
+        ,.commit_pkt_i(calculator.commit_pkt_cast_o)
+
+        ,.priv_mode_i(calculator.pipe_sys.csr.priv_mode_r)
+        ,.mstatus_i(calculator.pipe_sys.csr.mstatus_lo)
+        ,.mcause_i(calculator.pipe_sys.csr.mcause_lo)
+        ,.scause_i(calculator.pipe_sys.csr.scause_lo)
+
+        ,.ird_w_v_i(scheduler.iwb_pkt_cast_i.ird_w_v)
+        ,.ird_addr_i(scheduler.iwb_pkt_cast_i.rd_addr)
+        ,.ird_data_i(scheduler.iwb_pkt_cast_i.rd_data)
+
+        ,.frd_w_v_i(scheduler.fwb_pkt_cast_i.frd_w_v)
+        ,.frd_addr_i(scheduler.fwb_pkt_cast_i.rd_addr)
+        ,.frd_data_i(scheduler.fwb_pkt_cast_i.rd_data)
+
+        ,.cache_req_ready_and_i(calculator.pipe_mem.dcache.cache_req_ready_and_i)
+        ,.cache_req_v_i(calculator.pipe_mem.dcache.cache_req_v_o)
+        ,.cache_req_complete_i(calculator.pipe_mem.dcache.cache_req_complete_i)
+        ,.cache_req_nonblocking_i(calculator.pipe_mem.dcache.nonblocking_req)
+
+        ,.cosim_clk_i(top.cosim_clk)
+        ,.cosim_reset_i(top.cosim_reset)
+        );
+`endif
+
 `ifdef VCS
    import "DPI-C" context task cosim_main(string c_args);
    string c_args;

--- a/cosim/black-parrot-example/vcs/Makefile
+++ b/cosim/black-parrot-example/vcs/Makefile
@@ -4,9 +4,11 @@ include ../Makefile.design
 # Accelerator Software Settings
 #############################
 NBF_FILE     ?= $(abspath ../prog.nbf)
+ELF_FILE     ?= $(abspath ../prog.elf)
 HOST_PROGRAM ?= $(abspath ../ps.cpp)
 SIM_ARGS     += +c_args=$(NBF_FILE)
 
+DROMAJO_COSIM ?= 0
 SKIP_DRAM ?= -DSKIP_DRAM_TESTING
 BP_NCPUS ?= 1
 
@@ -18,6 +20,9 @@ CFLAGS += -DHP0_ENABLE -DHP0_ADDR_BASE=0x1000000U -DHP0_ADDR_WIDTH=32 -DHP0_DATA
 CFLAGS += -DSCRATCHPAD_ENABLE
 CFLAGS += -DBP_NCPUS=$(BP_NCPUS)
 CFLAGS += $(INCLUDES) $(SKIP_DRAM)
+ifeq ($(DROMAJO_COSIM),1)
+CFLAGS += -I$(BP_TOOLS_DIR)/dromajo/include
+endif
 
 # Enable backpressure, emulating context switches
 #CFLAGS += -DSIM_BACKPRESSURE_ENABLE
@@ -47,6 +52,13 @@ $(FLIST): $(BP_FLIST) $(BASE_FLIST)
 	echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dpi_gpio.v " >> $@
 	echo "$(COSIM_SRC_DIR)/bsg_nonsynth_dpi_to_axil.v" >> $@
 	echo "$(COSIM_SRC_DIR)/bsg_nonsynth_axil_to_dpi.v" >> $@
+	if [ "$(DROMAJO_COSIM)" = "1" ]; then \
+		echo "$(BLACKPARROT_DIR)/bp_top/test/common/bp_nonsynth_cosim.sv" >> $@; \
+		echo "$(BLACKPARROT_DIR)/bp_top/test/common/dromajo_cosim.cpp" >> $@; \
+		echo "$(BLACKPARROT_TOOLS_DIR)/install/lib/libdromajo_cosim.a" >> $@; \
+		echo "+define+DROMAJO_COSIM" >> $@; \
+		cp $(ELF_FILE) prog.elf; \
+	fi
 
 include $(TOP)/cosim/mk/Makefile.vcs
 

--- a/cosim/black-parrot-example/verilator/Makefile
+++ b/cosim/black-parrot-example/verilator/Makefile
@@ -4,9 +4,11 @@ include ../Makefile.design
 # Accelerator Software Settings
 #############################
 NBF_FILE     ?= $(abspath ../prog.nbf)
+ELF_FILE     ?= $(abspath ../prog.elf)
 HOST_PROGRAM ?= $(abspath ../ps.cpp)
 SIM_ARGS     += $(NBF_FILE)
 
+DROMAJO_COSIM ?= 0
 SKIP_DRAM ?= -DSKIP_DRAM_TESTING
 BP_NCPUS ?= 1
 
@@ -18,12 +20,15 @@ CFLAGS += -DHP0_ENABLE -DHP0_ADDR_BASE=0x1000000U -DHP0_ADDR_WIDTH=32 -DHP0_DATA
 CFLAGS += -DSCRATCHPAD_ENABLE
 CFLAGS += -DBP_NCPUS=$(BP_NCPUS)
 CFLAGS += $(INCLUDES) $(SKIP_DRAM)
+ifeq ($(DROMAJO_COSIM),1)
+CFLAGS += -I$(BP_TOOLS_DIR)/dromajo/include
+endif
 
 # Enable backpressure, emulating context switches
-CFLAGS += -DSIM_BACKPRESSURE_ENABLE
-CFLAGS += -DSIM_BACKPRESSURE_SEED=1234
-CFLAGS += -DSIM_BACKPRESSURE_CHANCE=5
-CFLAGS += -DSIM_BACKPRESSURE_LENGTH=100
+#CFLAGS += -DSIM_BACKPRESSURE_ENABLE
+#CFLAGS += -DSIM_BACKPRESSURE_SEED=1234
+#CFLAGS += -DSIM_BACKPRESSURE_CHANCE=5
+#CFLAGS += -DSIM_BACKPRESSURE_LENGTH=100
 
 #############################
 # Modify base flist
@@ -43,6 +48,13 @@ $(FLIST): $(BP_FLIST) $(BASE_FLIST)
 	echo "$(BASEJUMP_STL_DIR)/bsg_test/bsg_nonsynth_dpi_gpio.v " >> $@
 	echo "$(COSIM_SRC_DIR)/bsg_nonsynth_dpi_to_axil.v" >> $@
 	echo "$(COSIM_SRC_DIR)/bsg_nonsynth_axil_to_dpi.v" >> $@
+	if [ "$(DROMAJO_COSIM)" = "1" ]; then \
+		echo "$(BLACKPARROT_DIR)/bp_top/test/common/bp_nonsynth_cosim.sv" >> $@; \
+		echo "$(BLACKPARROT_DIR)/bp_top/test/common/dromajo_cosim.cpp" >> $@; \
+		echo "$(BLACKPARROT_TOOLS_DIR)/install/lib/libdromajo_cosim.a" >> $@; \
+		echo "+define+DROMAJO_COSIM" >> $@; \
+		cp $(ELF_FILE) prog.elf; \
+	fi
 
 include $(TOP)/cosim/mk/Makefile.verilator
 

--- a/cosim/mk/Makefile.vcs
+++ b/cosim/mk/Makefile.vcs
@@ -46,6 +46,8 @@ clean:
 	-rm -rf simv* vcdplus.vpd
 	-rm -rf build.log
 	-rm -rf run.log
+	-rm -rf prog.elf
+	-rm -rf *.trace
 
 view:
 	$(_DVE) -full64 -vpd vcdplus.vpd

--- a/cosim/mk/Makefile.verilator
+++ b/cosim/mk/Makefile.verilator
@@ -37,6 +37,8 @@ clean:
 	-rm -rf obj_dir/ *~ trace.fst
 	-rm -rf build.log
 	-rm -rf run.log
+	-rm -rf prog.elf
+	-rm -rf *.trace
 
 view:
 	gtkwave -f trace.fst


### PR DESCRIPTION
Useful for tracking down bugs in the AXI components for tests which pass in BP tethered but not zynq-parrot

Relies on #60 