### PR TITLE
Fix floating bresp in sim; add description for -debug_all in README

### DIFF
--- a/cosim/README.md
+++ b/cosim/README.md
@@ -24,3 +24,5 @@ See [The ZynqParrot Co-simulation Development Flow](https://docs.google.com/docu
 To install Verilator, see [Installation -- Verilator](https://verilator.org/guide/latest/install.html).
 
 To use the Black Parrot example, you will most likely want to build the software toolchain for RISC-V. The makefile for doing this is in the zynq-parrot/software directory.
+
+To have accurate VCS waveform dump, change the VCS option '-debug_pp' to '-debug_all' in mk/Makefile.vcs. Otherwise use '-debug_pp' to have faster simulation.

--- a/cosim/include/common/bsg_axil.h
+++ b/cosim/include/common/bsg_axil.h
@@ -387,6 +387,7 @@ public:
     this->p_wready = 0;
     // raise bvalid for response
     this->p_bvalid = 1;
+    this->p_bresp  = 0;
 
     // wait for response ready
     while (this->p_bready == 0) {


### PR DESCRIPTION
It seems like we forgot to assign a value to BRESP in bsg_axil.h. This PR adds this.

Also the VCS option -debug_pp sometimes leads to inaccurate waveform dump. To have accurate one users should use -debug_all instead (if simulation performance is not a concern). It might be useful to have some description about this in the README, so this PR adds this as well.