### PR TITLE
Adding in-place nbf generation

### DIFF
--- a/cosim/black-parrot-example/Makefile.design
+++ b/cosim/black-parrot-example/Makefile.design
@@ -9,3 +9,12 @@ BOARDNAME  ?= pynqz2
 TOP_MODULE ?= top
 BASENAME   ?= blackparrot
 
+#############################
+# Run Collateral for example
+#############################
+%.nbf:
+	$(MAKE) -C $(SOFTWARE_DIR) $(@F)
+	mv $(SOFTWARE_DIR)/$(@F) $@
+
+RUN_COLLATERAL = $(NBF_FILE)
+

--- a/cosim/black-parrot-minimal-example/Makefile.design
+++ b/cosim/black-parrot-minimal-example/Makefile.design
@@ -9,3 +9,12 @@ BOARDNAME  ?= pynqz2
 TOP_MODULE ?= top
 BASENAME   ?= blackparrot
 
+#############################
+# Run Collateral for example
+#############################
+%.nbf:
+	$(MAKE) -C $(SOFTWARE_DIR) $(@F)
+	mv $(SOFTWARE_DIR)/$(@F) $@
+
+RUN_COLLATERAL = $(NBF_FILE)
+

--- a/cosim/mk/Makefile.fpga
+++ b/cosim/mk/Makefile.fpga
@@ -18,7 +18,7 @@ all:
 	@grep -o -e "^[a-Z_%\.]*:" $(TOP)/cosim/mk/Makefile.fpga
 
 EXE ?= control-program
-run: $(EXE)
+run: $(EXE) $(RUN_COLLATERAL)
 	sudo ./$< $(SIM_ARGS) | tee run.log
 
 $(EXE): $(HOST_PROGRAM)
@@ -58,4 +58,5 @@ clean:
 	rm -rf $(EXE)
 	rm -rf sds_trace_data.dat
 	rm -rf $(BASENAME)_bd_1.bit $(BASENAME)_bd_1.hwh $(BASENAME)_bd_1_bd.tcl
+	-rm -rf *.nbf
 

--- a/cosim/mk/Makefile.vcs
+++ b/cosim/mk/Makefile.vcs
@@ -35,7 +35,7 @@ simv: $(HOST_PROGRAM) $(FLIST)
 		2>&1 | tee -i $(BUILD_LOG)
 
 RUN_LOG ?= run.log
-run: simv
+run: simv $(RUN_COLLATERAL)
 	./$< $(SIM_ARGS) $(TRACE) 2>&1 | tee -i $(RUN_LOG)
 
 clean:
@@ -48,6 +48,7 @@ clean:
 	-rm -rf run.log
 	-rm -rf prog.elf
 	-rm -rf *.trace
+	-rm -rf *.nbf
 
 view:
 	$(_DVE) -full64 -vpd vcdplus.vpd

--- a/cosim/mk/Makefile.verilator
+++ b/cosim/mk/Makefile.verilator
@@ -23,7 +23,7 @@ all:
 	@echo "## See the makefile for the fun things you can do in this directory"
 
 RUN_LOG ?= run.log
-run: obj_dir/V$(TOP_MODULE)
+run: obj_dir/V$(TOP_MODULE) $(RUN_COLLATERAL)
 	$< $(SIM_ARGS) $(TRACE) 2>&1 | tee -i $(RUN_LOG)
 
 BUILD_LOG ?= build.log
@@ -39,6 +39,7 @@ clean:
 	-rm -rf run.log
 	-rm -rf prog.elf
 	-rm -rf *.trace
+	-rm -rf *.nbf
 
 view:
 	gtkwave -f trace.fst

--- a/software/Makefile
+++ b/software/Makefile
@@ -12,7 +12,7 @@ SED ?= sed
 suite-binaries:=$(shell test -d $(BLACKPARROT_SDK_DIR)/prog/$(SUITE) && find $(BLACKPARROT_SDK_DIR)/prog/$(SUITE) -iname "*.riscv")
 
 checkout_tools:
-	cd ../software/import; git submodule update --init black-parrot-sdk
+	cd ../software/import; git submodule update --init $(BLACKPARROT_SDK_DIR)
 
 #build once (x86 server); takes about 15 minutes
 build_tools: checkout_tools
@@ -97,7 +97,7 @@ clean_logs:
 	rm -rf $(SOFTWARE_NBF_DIR)/*.log
 
 # run on x86
-VPATH := $(wildcard ../cosim/import/black-parrot-sdk/prog/*)
+VPATH := $(wildcard $(BLACKPARROT_SDK_DIR)/prog/*)
 %.nbf: %.riscv
 	$(RISCV_OBJCOPY) -O verilog $< $*.mem
 	$(SED) -i "s/@8/@0/g" $*.mem


### PR DESCRIPTION
This PR adds in-place NBF generation. For example, make clean run NBF_FILE=hello_world.nbf, hello_world.nbf will be created from black-parrot-sdk/prog/bp-tests/hello_world.riscv, if it does not exist. This is compatible with the old flow of pre-caching the NBFs but allows for more flexibility with different configurations