### PR TITLE
Switching to coroutine-based polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ bsg_manycore_machine.h
 *_bd_proj*
 *_ip_proj*
 *_bd_1_bd.tcl
+boost

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,24 @@ checkout:
 	cd $(TOP); git submodule update --init --recursive --checkout $(COSIM_IMPORT_DIR)
 	cd $(TOP); git submodule update --init --recursive --checkout $(SOFTWARE_IMPORT_DIR)
 
-prep: checkout
+BOOST_URL ?= https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.gz
+BOOST_BUILD_DIR ?= boost_1_82_0
+$(BOOST_BUILD_DIR): checkout
+	$(WGET) -c $(BOOST_URL) -O - | $(TAR) -xz
+
+boost: $(BOOST_BUILD_DIR)
+	rm -rf $(BOOST_ROOT)
+	cd $<; \
+		./bootstrap.sh --prefix=$(BOOST_ROOT)
+	cd $<; \
+		./b2 --prefix=$(BOOST_ROOT) \
+			toolset=gcc \
+			cxxflags="-std=c++14" \
+			linkflags="-std=c++14" \
+			install
+	rm -rf $<
+
+prep: boost
 	# BlackParrot
 	$(MAKE) -C $(BLACKPARROT_DIR) libs
 	$(MAKE) -C $(BLACKPARROT_TOOLS_DIR) tools

--- a/Makefile.common
+++ b/Makefile.common
@@ -45,8 +45,8 @@ endif
 
 export SOFTWARE_DIR          ?= $(TOP)/software
 export SOFTWARE_IMPORT_DIR   ?= $(SOFTWARE_DIR)/import
-export SOFTWARE_NBF_DIR      ?= $(SOFTWARE_DIR)/nbf
 export BLACKPARROT_SDK_DIR   ?= $(SOFTWARE_IMPORT_DIR)/black-parrot-sdk
+export BOOST_ROOT            ?= $(SOFTWARE_IMPORT_DIR)/boost
 # Override to zynq-parrot version
 export BP_SDK_DIR            ?= $(BLACKPARROT_SDK_DIR)
 export PLATFORM              ?= zynqparrot
@@ -79,6 +79,9 @@ export PYTHON          ?= $(PYTHON3)
 export SED      ?= sed
 export GREP     ?= grep
 export CAT      ?= cat
+export WGET     ?= wget
+export TAR      ?= tar
 
 export PATH := $(BP_TOOLS_DIR)/install/bin:$(BP_SDK_DIR)/install/bin:$(COSIM_PY_DIR):$(PATH)
+export LD_LIBRARY_PATH := $(BOOST_ROOT)/lib:$(LD_LIBRARY_PATH)
 

--- a/cosim/black-parrot-example/v/top_zynq.sv
+++ b/cosim/black-parrot-example/v/top_zynq.sv
@@ -427,12 +427,12 @@ module top_zynq
    // Zynq PA 0x8000_0000 .. 0x8FFF_FFFF -> AXI 0x0000_0000 .. 0x0FFF_FFFF -> BP 0x8000_0000 - 0x8FFF_FFFF
    // Zynq PA 0xA000_0000 .. 0xAFFF_FFFF -> AXI 0x2000_0000 .. 0x2FFF_FFFF -> BP 0x0000_0000 - 0x0FFF_FFFF
    
-   wire [bp_axil_addr_width_lp-1:0] s01_waddr_translated_lo = {~s01_axi_awaddr[29], 3'b0, s01_axi_awaddr[0+:28]};
+   wire [bp_axil_addr_width_lp-1:0] s01_awaddr_translated_lo = {~s01_axi_awaddr[29], 3'b0, s01_axi_awaddr[0+:28]};
    
    // Zynq PA 0x8000_0000 .. 0x8FFF_FFFF -> AXI 0x0000_0000 .. 0x0FFF_FFFF -> BP 0x8000_0000 - 0x8FFF_FFFF
    // Zynq PA 0xA000_0000 .. 0xAFFF_FFFF -> AXI 0x2000_0000 .. 0x2FFF_FFFF -> BP 0x0000_0000 - 0x0FFF_FFFF
    
-   wire [bp_axil_addr_width_lp-1:0] s01_raddr_translated_lo = {~s01_axi_araddr[29], 3'b0, s01_axi_araddr[0+:28]};
+   wire [bp_axil_addr_width_lp-1:0] s01_araddr_translated_lo = {~s01_axi_araddr[29], 3'b0, s01_axi_araddr[0+:28]};
 
    logic [C_S01_AXI_ADDR_WIDTH-1 : 0]           spack_axi_awaddr;
    logic [2 : 0]                                spack_axi_awprot;
@@ -567,6 +567,10 @@ module top_zynq
      ,.m01_axil_rready(m01_axi_rready)
      );
 
+  // TODO: Bug in zero-extension of Xcelium 21.09
+  wire [bp_axil_addr_width_lp-1:0] s02_awaddr_translated_lo = s02_axi_awaddr;
+  wire [bp_axil_addr_width_lp-1:0] s02_araddr_translated_lo = s02_axi_araddr;
+
   bsg_axil_mux
    #(.addr_width_p(bp_axil_addr_width_lp)
      ,.data_width_p(bp_axil_data_width_lp)
@@ -574,7 +578,7 @@ module top_zynq
    axil_mux
     (.clk_i(aclk)
      ,.reset_i(~aresetn)
-     ,.s00_axil_awaddr (s01_waddr_translated_lo)
+     ,.s00_axil_awaddr (s01_awaddr_translated_lo)
      ,.s00_axil_awprot (s01_axi_awprot)
      ,.s00_axil_awvalid(s01_axi_awvalid)
      ,.s00_axil_awready(s01_axi_awready)
@@ -585,7 +589,7 @@ module top_zynq
      ,.s00_axil_bresp  (s01_axi_bresp)
      ,.s00_axil_bvalid (s01_axi_bvalid)
      ,.s00_axil_bready (s01_axi_bready)
-     ,.s00_axil_araddr (s01_raddr_translated_lo)
+     ,.s00_axil_araddr (s01_araddr_translated_lo)
      ,.s00_axil_arprot (s01_axi_arprot)
      ,.s00_axil_arvalid(s01_axi_arvalid)
      ,.s00_axil_arready(s01_axi_arready)
@@ -594,7 +598,7 @@ module top_zynq
      ,.s00_axil_rvalid (s01_axi_rvalid)
      ,.s00_axil_rready (s01_axi_rready)
 
-     ,.s01_axil_awaddr (s02_axi_awaddr )
+     ,.s01_axil_awaddr (s02_awaddr_translated_lo)
      ,.s01_axil_awprot (s02_axi_awprot )
      ,.s01_axil_awvalid(s02_axi_awvalid)
      ,.s01_axil_awready(s02_axi_awready)
@@ -605,7 +609,7 @@ module top_zynq
      ,.s01_axil_bresp  (s02_axi_bresp  )
      ,.s01_axil_bvalid (s02_axi_bvalid )
      ,.s01_axil_bready (s02_axi_bready )
-     ,.s01_axil_araddr (s02_axi_araddr )
+     ,.s01_axil_araddr (s02_araddr_translated_lo)
      ,.s01_axil_arprot (s02_axi_arprot )
      ,.s01_axil_arvalid(s02_axi_arvalid)
      ,.s01_axil_arready(s02_axi_arready)
@@ -795,11 +799,11 @@ module top_zynq
 
    always @(negedge aclk)
      if (s01_axi_awvalid & s01_axi_awready)
-       if (debug_lp) $display("top_zynq: AXI Write Addr %x -> %x (BP)",s01_axi_awaddr,s01_waddr_translated_lo);
+       if (debug_lp) $display("top_zynq: AXI Write Addr %x -> %x (BP)",s01_axi_awaddr,s01_awaddr_translated_lo);
 
    always @(negedge aclk)
      if (s01_axi_arvalid & s01_axi_arready)
-       if (debug_lp) $display("top_zynq: AXI Read Addr %x -> %x (BP)",s01_axi_araddr,s01_raddr_translated_lo);
+       if (debug_lp) $display("top_zynq: AXI Read Addr %x -> %x (BP)",s01_axi_araddr,s01_araddr_translated_lo);
    // synopsys translate_on
 
 

--- a/cosim/black-parrot-example/vivado/Makefile
+++ b/cosim/black-parrot-example/vivado/Makefile
@@ -10,7 +10,7 @@ FLIST      ?= $(WD_FLIST) $(TOP_FLIST)
 
 $(WD_FLIST):
 	echo "+incdir+$(BASEJUMP_STL_DIR)/bsg_misc" >> $@
-	echo "+incdir+$BASEJUMP_STL_DIR/bsg_tag" >> $@
+	echo "+incdir+$(BASEJUMP_STL_DIR)/bsg_tag" >> $@
 	echo "$(BASEJUMP_STL_DIR)/bsg_misc/bsg_mux2_gatestack.v" >> $@
 	echo "$(BASEJUMP_STL_DIR)/bsg_async/bsg_launch_sync_sync.v" >> $@
 	echo "$(BASEJUMP_STL_DIR)/bsg_tag/bsg_tag_pkg.v" >> $@

--- a/cosim/black-parrot-minimal-example/v/bp_common_pkg.sv
+++ b/cosim/black-parrot-minimal-example/v/bp_common_pkg.sv
@@ -22,7 +22,7 @@ package bp_common_pkg;
     '{paddr_width: 34
 
       ,l2_slices : 1
-      ,l2_banks  : 2
+      ,l2_banks  : 1
 
       ,default : "inv"
       };

--- a/cosim/black-parrot-minimal-example/v/top_zynq.sv
+++ b/cosim/black-parrot-minimal-example/v/top_zynq.sv
@@ -8,11 +8,12 @@
 
 module top_zynq
  import zynq_pkg::*;
+ import bsg_blackparrot_pkg::*;
  import bp_common_pkg::*;
  import bp_be_pkg::*;
  import bp_me_pkg::*;
  import bsg_tag_pkg::*;
- #(parameter bp_params_e bp_params_p = e_bp_default_cfg
+ #(parameter bp_params_e bp_params_p = bp_cfg_gp
    `declare_bp_proc_params(bp_params_p)
    `declare_bp_bedrock_if_widths(paddr_width_p, lce_id_width_p, cce_id_width_p, did_width_p, lce_assoc_p)
 

--- a/cosim/include/common/bsg_axil.h
+++ b/cosim/include/common/bsg_axil.h
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <functional>
 #include <fstream>
 #include <iostream>
 #include <memory>
@@ -129,7 +130,7 @@ public:
   }
 
   // Wait for (low true) reset to be asserted by the testbench
-  void reset(void (*tick)()) {
+  void reset(std::function<void()> tick) {
     printf("bsg_zynq_pl: Entering reset\n");
     while (this->p_aresetn == 0) {
       tick();
@@ -137,7 +138,7 @@ public:
     printf("bsg_zynq_pl: Exiting reset\n");
   }
 
-  int axil_read_helper(uintptr_t address, void (*tick)()) {
+  int axil_read_helper(uintptr_t address, std::function<void()> tick) {
     int data;
     int timeout_counter = 0;
 
@@ -183,7 +184,7 @@ public:
   }
 
   void axil_write_helper(uintptr_t address, int32_t data, uint8_t wstrb,
-                         void (*tick)()) {
+                         std::function<void()> tick) {
     int timeout_counter = 0;
 
     assert(wstrb == 0xf); // we only support full int writes right now
@@ -198,6 +199,7 @@ public:
     bool aw_done = false;
     bool w_done = false;
 
+    int i = 0;
     // loop until both address and data consumed
     // subordinate is allowed to consume one before the other, or both at once
     // this loop will run at least once (and tick the clock)
@@ -301,7 +303,7 @@ public:
   }
 
   // Wait for (low true) reset to be asserted by the testbench
-  void reset(void (*tick)()) {
+  void reset(std::function<void()> tick) {
     printf("bsg_zynq_pl: Entering reset\n");
     while (this->p_aresetn == 0) {
       tick();
@@ -309,9 +311,8 @@ public:
     printf("bsg_zynq_pl: Exiting reset\n");
   }
 
-  void axil_read_helper(s_axil_device *p, void (*tick)()) {
+  void axil_read_helper(s_axil_device *p, std::function<void()> tick) {
     int timeout_counter = 0;
-    int data;
 
     this->p_arready = 1;
     while (this->p_arvalid == 0) {
@@ -346,7 +347,7 @@ public:
     return;
   }
 
-  int axil_write_helper(s_axil_device *p, void (*tick)()) {
+  int axil_write_helper(s_axil_device *p, std::function<void ()> tick) {
     int timeout_counter = 0;
 
     assert(this->p_wstrb == 0xf); // we only support full int writes right now

--- a/cosim/include/common/bsg_peripherals.h
+++ b/cosim/include/common/bsg_peripherals.h
@@ -46,10 +46,10 @@ public:
         *address = WATCHDOG_ADDRESS;
         *data = 'W'; // For 'woof'
         *wmask = 0xf;
+        bsg_pr_dbg_pl("  bsg_zynq_pl: watchdog send\n");
         return true;
     }
 
-    bsg_pr_dbg_pl("  bsg_zynq_pl: watchdog send\n");
     return false;
   }
 

--- a/cosim/include/common/bsg_zynq_pl_simulation.h
+++ b/cosim/include/common/bsg_zynq_pl_simulation.h
@@ -1,0 +1,242 @@
+// This is an implementation of the standardized host bsg_zynq_pl API
+// that can be swapped out with a separate implementation to run on the PS
+//
+
+#ifndef BSG_ZYNQ_PL_SIMULATION_H
+#define BSG_ZYNQ_PL_SIMULATION_H
+
+#include <cassert>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <svdpi.h>
+#include <unistd.h>
+#include <memory>
+#include <vector>
+
+#include <boost/coroutine2/all.hpp>
+
+#include "bsg_argparse.h"
+#include "bsg_axil.h"
+#include "bsg_printing.h"
+#include "bsg_nonsynth_dpi_gpio.hpp"
+#include "bsg_peripherals.h"
+#include "zynq_headers.h"
+
+using namespace std;
+using namespace bsg_nonsynth_dpi;
+using namespace boost::coroutines2;
+using namespace std::placeholders;
+
+class bsg_zynq_pl_simulation {
+    protected:
+
+        std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > axi_gp0;
+        std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
+        std::unique_ptr<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> > axi_gp2;
+        std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
+
+        std::unique_ptr<zynq_scratchpad> scratchpad;
+        std::unique_ptr<zynq_watchdog> watchdog;
+
+        coroutine<void>::pull_type *co_next;
+        coroutine<void>::pull_type *co_polls;
+        coroutine<void>::pull_type *co_pollm;
+
+        std::function<void ()> f_tick = std::bind(&bsg_zynq_pl_simulation::tick, this);
+        std::function<void ()> f_next_tick = std::bind(&bsg_zynq_pl_simulation::next_tick, this);
+        std::function<void ()> f_poll_tick = std::bind(&bsg_zynq_pl_simulation::poll_tick, this);
+
+        void next(coroutine<void>::push_type &yield) {
+            while (1) {
+                tick();
+                yield();
+            }
+        }
+
+        void init() {
+#ifdef SIM_BACKPRESSURE_ENABLE
+            srand(SIM_BACKPRESSURE_SEED);
+#endif
+#ifdef SCRATCHPAD_ENABLE
+            scratchpad = std::make_unique<zynq_scratchpad>();
+#endif
+#ifdef WATCHDOG_ENABLE
+            watchdog = std::make_unique<zynq_watchdog>();
+#endif
+#ifdef GP0_ENABLE
+            axi_gp0 = std::make_unique<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> >(
+                    STRINGIFY(GP0_HIER_BASE));
+            axi_gp0->reset(f_tick);
+#endif
+#ifdef GP1_ENABLE
+            axi_gp1 = std::make_unique<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> >(
+                    STRINGIFY(GP1_HIER_BASE));
+            axi_gp1->reset(f_tick);
+#endif
+#ifdef GP2_ENABLE
+            axi_gp2 = std::make_unique<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> >(
+                    STRINGIFY(GP2_HIER_BASE));
+            axi_gp2->reset(f_tick);
+            co_pollm = new coroutine<void>::pull_type{std::bind(&bsg_zynq_pl_simulation::axilm_poll, this, _1)};
+            (*co_pollm)();
+#endif
+#ifdef HP0_ENABLE
+            axi_hp0 = std::make_unique<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> >(
+                    STRINGIFY(HP0_HIER_BASE));
+            axi_hp0->reset(f_tick);
+            co_polls = new coroutine<void>::pull_type{std::bind(&bsg_zynq_pl_simulation::axils_poll, this, _1)};
+            (*co_polls)();
+#endif
+            // Start the main tick thread
+            co_next = new coroutine<void>::pull_type{std::bind(&bsg_zynq_pl_simulation::next, this, _1)};
+            (*co_next)();
+        }
+
+#ifdef HP0_ENABLE
+        void axils_poll(coroutine<void>::push_type &yield) {
+            while (1) {
+#ifdef SIM_BACKPRESSURE_ENABLE
+                if ((rand() % 100) < SIM_BACKPRESSURE_CHANCE) {
+                    for (int i = 0; i < SIM_BACKPRESSURE_LENGTH; i++) {
+                        yield();
+                    }
+                }
+#endif
+                int araddr = axi_hp0->p_araddr;
+                if (!axi_hp0->p_arvalid) {
+                    yield();
+#ifdef SCRATCHPAD_ENABLE
+                } else if (scratchpad->is_read(araddr)) {
+                    axi_hp0->axil_read_helper((s_axil_device *)scratchpad.get(), f_next_tick);
+#endif
+                } else {
+                    bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device read at [%x]\n", araddr);
+                }
+
+                int awaddr = axi_hp0->p_awaddr;
+                if (!axi_hp0->p_awvalid) {
+                    yield();
+#ifdef SCRATCHPAD_ENABLE
+                } else if (scratchpad->is_write(awaddr)) {
+                    axi_hp0->axil_write_helper((s_axil_device *)scratchpad.get(), f_next_tick);
+#endif
+                } else {
+                    bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device write at [%x]\n", awaddr);
+                }
+            }
+        }
+#endif
+
+#ifdef GP2_ENABLE
+        void axilm_poll(coroutine<void>::push_type &yield) {
+            uintptr_t address;
+            int32_t data, ret;
+            uint8_t wmask;
+
+            while (1) {
+                if (0) {
+#ifdef WATCHDOG_ENABLE
+                } else if (watchdog->pending_write(&address, &data, &wmask)) {
+                    axi_gp2->axil_write_helper(address, data, wmask, f_next_tick);
+                    watchdog->return_write();
+                } else if (watchdog->pending_read(&address)) {
+                    ret = axi_gp2->axil_read_helper(address, f_next_tick);
+                    watchdog->return_read(ret);
+#endif
+                } else {
+                    yield();
+                }
+            }
+        }
+#endif
+
+    public:
+
+#ifdef AXI_ENABLE
+        virtual int32_t axil_read(uintptr_t address) {
+            uintptr_t address_orig = address;
+            int index = -1;
+            int data;
+
+            // we subtract the bases to make it consistent with the Zynq AXI IPI
+            // implementation
+
+            if (address >= GP0_ADDR_BASE &&
+                    address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
+                index = 0;
+                address = address - GP0_ADDR_BASE;
+            } else if (address >= GP1_ADDR_BASE &&
+                    address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
+                index = 1;
+                address = address - GP1_ADDR_BASE;
+            } else {
+                bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
+                return -1;
+            }
+
+            if (index == 0) {
+                data = axi_gp0->axil_read_helper(address, f_tick);
+            } else if (index == 1) {
+                data = axi_gp1->axil_read_helper(address, f_tick);
+            }
+
+            bsg_pr_dbg_pl("  bsg_zynq_pl: AXI reading [%x] -> port %d, [%x]->%8.8x\n",
+                    address_orig, index, address, data);
+
+            return data;
+        }
+
+        virtual void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) {
+            uintptr_t address_orig = address;
+            int index = -1;
+
+            // we subtract the bases to make it consistent with the Zynq AXI IPI
+            // implementation
+
+            if (address >= GP0_ADDR_BASE &&
+                    address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
+                index = 0;
+                address = address - GP0_ADDR_BASE;
+            } else if (address >= GP1_ADDR_BASE &&
+                    address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
+                index = 1;
+                address = address - GP1_ADDR_BASE;
+            } else {
+                bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
+                return;
+            }
+
+            bsg_pr_dbg_pl("  bsg_zynq_pl: AXI writing [%x] -> port %d, [%x]<-%8.8x\n",
+                    address_orig, index, address, data);
+
+            if (index == 0) {
+                axi_gp0->axil_write_helper(address, data, wstrb, f_tick);
+            } else if (index == 1) {
+                axi_gp1->axil_write_helper(address, data, wstrb, f_tick);
+            }
+        }
+#endif
+
+        virtual void tick(void) = 0;
+        virtual void done(void) = 0;
+
+        virtual void next_tick() {
+            (*co_next)();
+        }
+
+        virtual void poll_tick() {
+#ifdef HP0_ENABLE
+            (*co_polls)();
+#endif
+#ifdef GP2_ENABLE
+            (*co_pollm)();
+#endif
+            (*co_next)();
+        }
+};
+
+#endif

--- a/cosim/include/common/zynq_headers.h
+++ b/cosim/include/common/zynq_headers.h
@@ -69,6 +69,14 @@ static uintptr_t gp1_addr_base = (uintptr_t) GP1_ADDR_BASE;
 #endif
 #endif
 
+#ifdef GP0_ENABLE
+#define AXI_ENABLE
+#endif
+
+#ifdef GP1_ENABLE
+#define AXI_ENABLE
+#endif
+
 #ifndef GP2_ENABLE
 #define GP2_ADDR_WIDTH 0
 #define GP2_DATA_WIDTH 0

--- a/cosim/include/vcs/bsg_zynq_pl.h
+++ b/cosim/include/vcs/bsg_zynq_pl.h
@@ -16,184 +16,46 @@
 #include <unistd.h>
 #include <memory>
 #include <vector>
-#include "bsg_argparse.h"
-#include "bsg_axil.h"
-#include "bsg_printing.h"
-#include "bsg_nonsynth_dpi_gpio.hpp"
-#include "bsg_peripherals.h"
-#include "zynq_headers.h"
+
+#include "bsg_zynq_pl_simulation.h"
 
 extern "C" { void bsg_dpi_next(); }
 
-using namespace std;
-using namespace bsg_nonsynth_dpi;
+class bsg_zynq_pl : public bsg_zynq_pl_simulation {
+    public:
+        bsg_zynq_pl(int argc, char *argv[]) {
+            tick();
+            init();
+        }
 
-class bsg_zynq_pl {
+        ~bsg_zynq_pl(void) { }
 
-  std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > axi_gp0;
-  std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
-  std::unique_ptr<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> > axi_gp2;
-  std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
+#ifdef AXI_ENABLE
+        int32_t axil_read(uintptr_t address) override {
+            return bsg_zynq_pl_simulation::axil_read(address);
+        }
 
-  std::unique_ptr<zynq_scratchpad> scratchpad;
-  std::unique_ptr<zynq_watchdog> watchdog;
-
-public:
-  // Move the simulation forward to the next DPI event
-  static void tick(void) {
-    bsg_dpi_next();
-  }
-
-  static void done(void) { 
-    bsg_pr_info("  bsg_zynq_pl: done() called, exiting\n");
-  }
-
-  bsg_zynq_pl(int argc, char *argv[]) {
-    // Initialize backpressure (if any)
-#ifdef SIM_BACKPRESSURE_ENABLE
-    srand(SIM_BACKPRESSURE_SEED);
+        void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) override {
+            bsg_zynq_pl_simulation::axil_write(address, data, wstrb);
+        }
 #endif
 
-    tick();
-#ifdef GP0_ENABLE
-    axi_gp0 = std::make_unique<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> >(
-        STRINGIFY(GP0_HIER_BASE));
-    axi_gp0->reset(tick);
-#endif
-#ifdef GP1_ENABLE
-    axi_gp1 = std::make_unique<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> >(
-        STRINGIFY(GP1_HIER_BASE));
-    axi_gp1->reset(tick);
-#endif
-#ifdef GP2_ENABLE
-    axi_gp2 = std::make_unique<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> >(
-        STRINGIFY(GP2_HIER_BASE));
-    axi_gp2->reset(tick);
-#endif
-#ifdef HP0_ENABLE
-    axi_hp0 = std::make_unique<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> >(
-        STRINGIFY(HP0_HIER_BASE));
-    axi_hp0->reset(tick);
-#ifdef SCRATCHPAD_ENABLE
-    scratchpad = std::make_unique<zynq_scratchpad>();
-#endif
-#ifdef WATCHDOG_ENABLE
-    watchdog = std::make_unique<zynq_watchdog>();
-#endif
-#endif
-  }
+        void tick(void) override {
+            bsg_dpi_next();
+        }
 
-  ~bsg_zynq_pl(void) {}
+        void done(void) override {
+            bsg_pr_info("  bsg_zynq_pl: done() called, exiting\n");
+        }
 
-  void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) {
-    uintptr_t address_orig = address;
-    int index = -1;
+        void next_tick() override {
+            bsg_zynq_pl_simulation::next_tick();
+        }
 
-    // we subtract the bases to make it consistent with the Zynq AXI IPI
-    // implementation
-
-    if (address >= GP0_ADDR_BASE &&
-        address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
-      index = 0;
-      address = address - GP0_ADDR_BASE;
-    } else if (address >= GP1_ADDR_BASE &&
-               address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
-      index = 1;
-      address = address - GP1_ADDR_BASE;
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
-    }
-
-    bsg_pr_dbg_pl("  bsg_zynq_pl: AXI writing [%x] -> port %d, [%x]<-%8.8x\n",
-                  address_orig, index, address, data);
-
-    if (index == 0) {
-      axi_gp0->axil_write_helper(address, data, wstrb, tick);
-    } else if (index == 1) {
-      axi_gp1->axil_write_helper(address, data, wstrb, tick);
-    }
-  }
-
-  int32_t axil_read(uintptr_t address) {
-    uintptr_t address_orig = address;
-    int index = -1;
-    int data;
-
-    // we subtract the bases to make it consistent with the Zynq AXI IPI
-    // implementation
-
-    if (address >= GP0_ADDR_BASE &&
-        address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
-      index = 0;
-      address = address - GP0_ADDR_BASE;
-    } else if (address >= GP1_ADDR_BASE &&
-               address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
-      index = 1;
-      address = address - GP1_ADDR_BASE;
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
-    }
-
-    if (index == 0) {
-      data = axi_gp0->axil_read_helper(address, tick);
-    } else if (index == 1) {
-      data = axi_gp1->axil_read_helper(address, tick);
-    }
-
-    bsg_pr_dbg_pl("  bsg_zynq_pl: AXI reading [%x] -> port %d, [%x]->%8.8x\n",
-                  address_orig, index, address, data);
-
-    return data;
-  }
-
-  void axil_poll() {
-#ifdef SIM_BACKPRESSURE_ENABLE
-    if ((rand() % 100) < SIM_BACKPRESSURE_CHANCE) {
-      for (int i = 0; i < SIM_BACKPRESSURE_LENGTH; i++) {
-        tick();
-      }
-    }
-#endif
-
-#ifdef HP0_ENABLE
-    int araddr = axi_hp0->p_araddr;
-    if (!axi_hp0->p_arvalid) {
-#ifdef SCRATCHPAD_ENABLE
-    } else if (scratchpad->is_read(araddr)) {
-      axi_hp0->axil_read_helper((s_axil_device *)scratchpad.get(), tick);
-#endif
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device read at [%x]\n", araddr);
-    }
-#endif
-
-#ifdef HP0_ENABLE
-    int awaddr = axi_hp0->p_awaddr;
-    if (!axi_hp0->p_awvalid) {
-#ifdef SCRATCHPAD_ENABLE
-    } else if (scratchpad->is_write(awaddr)) {
-      axi_hp0->axil_write_helper((s_axil_device *)scratchpad.get(), tick);
-#endif
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device write at [%x]\n", awaddr);
-    }
-#endif
-
-#ifdef GP2_ENABLE
-#ifdef WATCHDOG_ENABLE
-    uintptr_t address;
-    int32_t data, ret;
-    uint8_t wmask;
-    if (watchdog->pending_write(&address, &data, &wmask)) {
-      axi_gp2->axil_write_helper(address, data, wmask, tick);
-      watchdog->return_write();
-    } else if (watchdog->pending_read(&address)) {
-      ret = axi_gp2->axil_read_helper(address, tick);
-      watchdog->return_read(ret);
-    }
-#endif
-#endif
-  }
+        void poll_tick() override {
+            bsg_zynq_pl_simulation::poll_tick();
+        }
 };
 
 #endif
+

--- a/cosim/include/verilator/bsg_zynq_pl.h
+++ b/cosim/include/verilator/bsg_zynq_pl.h
@@ -19,209 +19,70 @@
 #include "verilated_fst_c.h"
 #include "verilated_cov.h"
 
-using namespace std;
-using namespace bsg_nonsynth_dpi;
-
+#include "bsg_zynq_pl_simulation.h"
 #include "Vtop.h"
 #include "verilated.h"
 
-class bsg_zynq_pl {
-  static Vtop *tb;
-  static VerilatedFstC *wf;
+class bsg_zynq_pl : public bsg_zynq_pl_simulation {
+    Vtop *tb;
+    VerilatedFstC *wf;
 
-  std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > axi_gp0;
-  std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
-  std::unique_ptr<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> > axi_gp2;
-  std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
-  std::unique_ptr<zynq_scratchpad> scratchpad;
-  std::unique_ptr<zynq_watchdog> watchdog;
+    public:
+        bsg_zynq_pl(int argc, char *argv[]) {
+            // Initialize Verilators variables
+            Verilated::commandArgs(argc, argv);
 
-public:
-  // Each bsg_timekeeper::next() moves to the next clock edge
-  //   so we need 2 to perform one full clock cycle.
-  // If your design does not evaluate things on negedge, you could omit
-  //   the first eval, but BSG designs tend to do assertions on negedge
-  //   at the least.
-  static void tick(void) {
-    tb->eval();
-    wf->dump(sc_time_stamp());
-    bsg_timekeeper::next();
-    tb->eval();
-    wf->dump(sc_time_stamp());
-    bsg_timekeeper::next();
-  }
+            // turn on tracing
+            Verilated::traceEverOn(true);
 
-  static void done(void) {
-    printf("bsg_zynq_pl: done() called, exiting\n");
-    wf->close();
-  }
+            tb = new Vtop();
 
-  bsg_zynq_pl(int argc, char *argv[]) {
-    // Initialize Verilators variables
-    Verilated::commandArgs(argc, argv);
+            wf = new VerilatedFstC;
+            tb->trace(wf, 10);
+            wf->open("trace.fst");
 
-    // turn on tracing
-    Verilated::traceEverOn(true);
+            tick();
+            init();
+        }
 
-    tb = new Vtop();
+        ~bsg_zynq_pl(void) { }
 
-    wf = new VerilatedFstC;
-    tb->trace(wf, 10);
-    wf->open("trace.fst");
+#ifdef AXI_ENABLE
+        int32_t axil_read(uintptr_t address) override {
+            return bsg_zynq_pl_simulation::axil_read(address);
+        }
 
-    // Initialize backpressure (if any)
-#ifdef SIM_BACKPRESSURE_ENABLE
-    srand(SIM_BACKPRESSURE_SEED);
+        void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) override {
+            bsg_zynq_pl_simulation::axil_write(address, data, wstrb);
+        }
 #endif
 
-    // Tick once to register clock generators
-    tb->eval();
-    tick();
-#ifdef GP0_ENABLE
-    axi_gp0 = std::make_unique<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> >(
-        STRINGIFY(GP0_HIER_BASE));
-    axi_gp0->reset(tick);
-#endif
-#ifdef GP1_ENABLE
-    axi_gp1 = std::make_unique<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> >(
-        STRINGIFY(GP1_HIER_BASE));
-    axi_gp1->reset(tick);
-#endif
-#ifdef HP0_ENABLE
-    axi_hp0 = std::make_unique<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> >(
-        STRINGIFY(HP0_HIER_BASE));
-    axi_hp0->reset(tick);
-#endif
-#ifdef GP2_ENABLE
-    axi_gp2 = std::make_unique<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> >(
-        STRINGIFY(GP2_HIER_BASE));
-    axi_gp2->reset(tick);
-#ifdef SCRATCHPAD_ENABLE
-    scratchpad = std::make_unique<zynq_scratchpad>();
-#endif
-#ifdef WATCHDOG_ENABLE
-    watchdog = std::make_unique<zynq_watchdog>();
-#endif
-#endif
-  }
+        // Each bsg_timekeeper::next() moves to the next clock edge
+        //   so we need 2 to perform one full clock cycle.
+        // If your design does not evaluate things on negedge, you could omit
+        //   the first eval, but BSG designs tend to do assertions on negedge
+        //   at the least.
+        void tick(void) override {
+            tb->eval();
+            wf->dump(sc_time_stamp());
+            bsg_timekeeper::next();
+            tb->eval();
+            wf->dump(sc_time_stamp());
+            bsg_timekeeper::next();
+        }
 
-  ~bsg_zynq_pl(void) {
-    // Causes segfault, double free?
-    // delete tb;
-  }
+        void done(void) override {
+            printf("bsg_zynq_pl: done() called, exiting\n");
+            wf->close();
+        }
 
-  void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) {
-    int address_orig = address;
-    int index = -1;
+        void next_tick() override {
+            bsg_zynq_pl_simulation::next_tick();
+        }
 
-    // we subtract the bases to make it consistent with the Zynq AXI IPI
-    // implementation
-
-    if (address >= GP0_ADDR_BASE &&
-        address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
-      index = 0;
-      address = address - GP0_ADDR_BASE;
-    } else if (address >= GP1_ADDR_BASE &&
-               address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
-      index = 1;
-      address = address - GP1_ADDR_BASE;
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
-    }
-
-    bsg_pr_dbg_pl("  bsg_zynq_pl: AXI writing [%x] -> port %d, [%x]<-%8.8x\n",
-                  address_orig, index, address, data);
-
-    if (index == 0) {
-      axi_gp0->axil_write_helper(address, data, wstrb, tick);
-    } else if (index == 1) {
-      axi_gp1->axil_write_helper(address, data, wstrb, tick);
-    }
-  }
-
-  int axil_read(uintptr_t address) {
-    int address_orig = address;
-    int index = -1;
-    int data;
-
-    // we subtract the bases to make it consistent with the Zynq AXI IPI
-    // implementation
-
-    if (address >= GP0_ADDR_BASE &&
-        address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
-      index = 0;
-      address = address - GP0_ADDR_BASE;
-    } else if (address >= GP1_ADDR_BASE &&
-               address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
-      index = 1;
-      address = address - GP1_ADDR_BASE;
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
-    }
-
-    if (index == 0) {
-      data = axi_gp0->axil_read_helper(address, tick);
-    } else if (index == 1) {
-      data = axi_gp1->axil_read_helper(address, tick);
-    }
-
-    bsg_pr_dbg_pl("  bsg_zynq_pl: AXI reading [%x] -> port %d, [%x]->%8.8x\n",
-                  address_orig, index, address, data);
-
-    return data;
-  }
-
-  void axil_poll() {
-#ifdef SIM_BACKPRESSURE_ENABLE
-    if ((rand() % 100) < SIM_BACKPRESSURE_CHANCE) {
-      for (int i = 0; i < SIM_BACKPRESSURE_LENGTH; i++) {
-        tick();
-      }
-    }
-#endif
-
-#ifdef HP0_ENABLE
-    int araddr = axi_hp0->p_araddr;
-    if (!axi_hp0->p_arvalid) {
-#ifdef SCRATCHPAD_ENABLE
-    } else if (scratchpad->is_read(araddr)) {
-      axi_hp0->axil_read_helper((s_axil_device *)scratchpad.get(), tick);
-#endif
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device read at [%x]\n", araddr);
-    }
-#endif
-
-#ifdef HP0_ENABLE
-    int awaddr = axi_hp0->p_awaddr;
-    if (!axi_hp0->p_awvalid) {
-#ifdef SCRATCHPAD_ENABLE
-    } else if (scratchpad->is_write(awaddr)) {
-      axi_hp0->axil_write_helper((s_axil_device *)scratchpad.get(), tick);
-#endif
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device write at [%x]\n", awaddr);
-    }
-#endif
-
-#ifdef GP2_ENABLE
-#ifdef WATCHDOG_ENABLE
-    uintptr_t address;
-    int32_t data, ret;
-    uint8_t wmask;
-    if (watchdog->pending_write(&address, &data, &wmask)) {
-      axi_gp2->axil_write_helper(address, data, wmask, tick);
-      watchdog->return_write();
-    } else if (watchdog->pending_read(&address)) {
-      ret = axi_gp2->axil_read_helper(address, tick);
-      watchdog->return_read(ret);
-    }
-#endif
-#endif
-  }
+        void poll_tick() override {
+            bsg_zynq_pl_simulation::poll_tick();
+        }
 };
-
-Vtop *bsg_zynq_pl::tb;
-VerilatedFstC *bsg_zynq_pl::wf;
 
 #endif

--- a/cosim/include/xcelium/bsg_zynq_pl.h
+++ b/cosim/include/xcelium/bsg_zynq_pl.h
@@ -16,184 +16,46 @@
 #include <unistd.h>
 #include <memory>
 #include <vector>
-#include "bsg_argparse.h"
-#include "bsg_axil.h"
-#include "bsg_printing.h"
-#include "bsg_nonsynth_dpi_gpio.hpp"
-#include "bsg_peripherals.h"
-#include "zynq_headers.h"
+
+#include "bsg_zynq_pl_simulation.h"
 
 extern "C" { void bsg_dpi_next(); }
 
-using namespace std;
-using namespace bsg_nonsynth_dpi;
+class bsg_zynq_pl : public bsg_zynq_pl_simulation {
+    public:
+        bsg_zynq_pl(int argc, char *argv[]) {
+            tick();
+            init();
+        }
 
-class bsg_zynq_pl {
+        ~bsg_zynq_pl(void) { }
 
-  std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > axi_gp0;
-  std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
-  std::unique_ptr<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> > axi_gp2;
-  std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
+#ifdef AXI_ENABLE
+        int32_t axil_read(uintptr_t address) override {
+            return bsg_zynq_pl_simulation::axil_read(address);
+        }
 
-  std::unique_ptr<zynq_scratchpad> scratchpad;
-  std::unique_ptr<zynq_watchdog> watchdog;
-
-public:
-  // Move the simulation forward to the next DPI event
-  static void tick(void) {
-    bsg_dpi_next();
-  }
-
-  static void done(void) { 
-    bsg_pr_info("  bsg_zynq_pl: done() called, exiting\n");
-  }
-
-  bsg_zynq_pl(int argc, char *argv[]) {
-    // Initialize backpressure (if any)
-#ifdef SIM_BACKPRESSURE_ENABLE
-    srand(SIM_BACKPRESSURE_SEED);
+        void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) override {
+            bsg_zynq_pl_simulation::axil_write(address, data, wstrb);
+        }
 #endif
 
-    tick();
-#ifdef GP0_ENABLE
-    axi_gp0 = std::make_unique<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> >(
-        STRINGIFY(GP0_HIER_BASE));
-    axi_gp0->reset(tick);
-#endif
-#ifdef GP1_ENABLE
-    axi_gp1 = std::make_unique<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> >(
-        STRINGIFY(GP1_HIER_BASE));
-    axi_gp1->reset(tick);
-#endif
-#ifdef GP2_ENABLE
-    axi_gp2 = std::make_unique<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> >(
-        STRINGIFY(GP2_HIER_BASE));
-    axi_gp2->reset(tick);
-#endif
-#ifdef HP0_ENABLE
-    axi_hp0 = std::make_unique<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> >(
-        STRINGIFY(HP0_HIER_BASE));
-    axi_hp0->reset(tick);
-#ifdef SCRATCHPAD_ENABLE
-    scratchpad = std::make_unique<zynq_scratchpad>();
-#endif
-#ifdef WATCHDOG_ENABLE
-    watchdog = std::make_unique<zynq_watchdog>();
-#endif
-#endif
-  }
+        void tick(void) override {
+            bsg_dpi_next();
+        }
 
-  ~bsg_zynq_pl(void) {}
+        void done(void) override {
+            bsg_pr_info("  bsg_zynq_pl: done() called, exiting\n");
+        }
 
-  void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) {
-    uintptr_t address_orig = address;
-    int index = -1;
+        void next_tick() override {
+            bsg_zynq_pl_simulation::next_tick();
+        }
 
-    // we subtract the bases to make it consistent with the Zynq AXI IPI
-    // implementation
-
-    if (address >= GP0_ADDR_BASE &&
-        address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
-      index = 0;
-      address = address - GP0_ADDR_BASE;
-    } else if (address >= GP1_ADDR_BASE &&
-               address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
-      index = 1;
-      address = address - GP1_ADDR_BASE;
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
-    }
-
-    bsg_pr_dbg_pl("  bsg_zynq_pl: AXI writing [%x] -> port %d, [%x]<-%8.8x\n",
-                  address_orig, index, address, data);
-
-    if (index == 0) {
-      axi_gp0->axil_write_helper(address, data, wstrb, tick);
-    } else if (index == 1) {
-      axi_gp1->axil_write_helper(address, data, wstrb, tick);
-    }
-  }
-
-  int32_t axil_read(uintptr_t address) {
-    uintptr_t address_orig = address;
-    int index = -1;
-    int data;
-
-    // we subtract the bases to make it consistent with the Zynq AXI IPI
-    // implementation
-
-    if (address >= GP0_ADDR_BASE &&
-        address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
-      index = 0;
-      address = address - GP0_ADDR_BASE;
-    } else if (address >= GP1_ADDR_BASE &&
-               address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
-      index = 1;
-      address = address - GP1_ADDR_BASE;
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
-    }
-
-    if (index == 0) {
-      data = axi_gp0->axil_read_helper(address, tick);
-    } else if (index == 1) {
-      data = axi_gp1->axil_read_helper(address, tick);
-    }
-
-    bsg_pr_dbg_pl("  bsg_zynq_pl: AXI reading [%x] -> port %d, [%x]->%8.8x\n",
-                  address_orig, index, address, data);
-
-    return data;
-  }
-
-  void axil_poll() {
-#ifdef SIM_BACKPRESSURE_ENABLE
-    if ((rand() % 100) < SIM_BACKPRESSURE_CHANCE) {
-      for (int i = 0; i < SIM_BACKPRESSURE_LENGTH; i++) {
-        tick();
-      }
-    }
-#endif
-
-#ifdef HP0_ENABLE
-    int araddr = axi_hp0->p_araddr;
-    if (!axi_hp0->p_arvalid) {
-#ifdef SCRATCHPAD_ENABLE
-    } else if (scratchpad->is_read(araddr)) {
-      axi_hp0->axil_read_helper((s_axil_device *)scratchpad.get(), tick);
-#endif
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device read at [%x]\n", araddr);
-    }
-#endif
-
-#ifdef HP0_ENABLE
-    int awaddr = axi_hp0->p_awaddr;
-    if (!axi_hp0->p_awvalid) {
-#ifdef SCRATCHPAD_ENABLE
-    } else if (scratchpad->is_write(awaddr)) {
-      axi_hp0->axil_write_helper((s_axil_device *)scratchpad.get(), tick);
-#endif
-    } else {
-      bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device write at [%x]\n", awaddr);
-    }
-#endif
-
-#ifdef GP2_ENABLE
-#ifdef WATCHDOG_ENABLE
-    uintptr_t address;
-    int32_t data, ret;
-    uint8_t wmask;
-    if (watchdog->pending_write(&address, &data, &wmask)) {
-      axi_gp2->axil_write_helper(address, data, wmask, tick);
-      watchdog->return_write();
-    } else if (watchdog->pending_read(&address)) {
-      ret = axi_gp2->axil_read_helper(address, tick);
-      watchdog->return_read(ret);
-    }
-#endif
-#endif
-  }
+        void poll_tick() override {
+            bsg_zynq_pl_simulation::poll_tick();
+        }
 };
 
 #endif
+

--- a/cosim/mk/Makefile.vcs
+++ b/cosim/mk/Makefile.vcs
@@ -16,8 +16,10 @@ VCS_OPTS += +incdir+$(COSIM_DIR)/include/vcs
 CFLAGS += -DVCS
 CFLAGS += -std=c++14
 
-LDFLAGS += -lpthread
+LDFLAGS += -L$(BOOST_ROOT)/lib
+LDFLAGS += -lboost_coroutine -lboost_context -lboost_system
 
+CINCLUDES += -I$(BOOST_ROOT)/include
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/common
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/vcs
 CINCLUDES += -I$(BASEJUMP_STL_DIR)/bsg_mem
@@ -37,7 +39,7 @@ simv: $(HOST_PROGRAM) $(FLIST) $(BUILD_COLLATERAL)
 
 RUN_LOG ?= run.log
 run: simv $(RUN_COLLATERAL)
-	./$< $(SIM_ARGS) $(TRACE) 2>&1 | tee -i $(RUN_LOG)
+	./$< $(SIM_ARGS) $(SIM_LIBS) $(TRACE) 2>&1 | tee -i $(RUN_LOG)
 
 clean:
 	rm -rf csrc/

--- a/cosim/mk/Makefile.verilator
+++ b/cosim/mk/Makefile.verilator
@@ -10,8 +10,10 @@ VV_OPTS += +incdir+$(COSIM_DIR)/include/verilator
 CFLAGS += -DVERILATOR
 CFLAGS += -std=c++14
 
-LDFLAGS += -lpthread
+LDFLAGS += -L$(BOOST_ROOT)/lib
+LDFLAGS += -lboost_coroutine -lboost_context -lboost_system
 
+CINCLUDES += -I$(BOOST_ROOT)/include
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/common
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/verilator
 CINCLUDES += -I$(BASEJUMP_STL_DIR)/bsg_mem

--- a/cosim/mk/Makefile.xcelium
+++ b/cosim/mk/Makefile.xcelium
@@ -9,9 +9,14 @@ XRUN_OPTS += -top $(TOP_MODULE)
 XRUN_OPTS += +incdir+$(COSIM_DIR)/include/xcelium
 XRUN_OPTS += -access +rc
 XRUN_OPTS += -dpi -dynamic
+XRUN_OPTS += -disable_sem2009
 
 CFLAGS += -DXCELIUM
 
+LDFLAGS += -L$(BOOST_ROOT)/lib
+LDFLAGS += -lboost_coroutine -lboost_context -lboost_system
+
+CINCLUDES += -I$(BOOST_ROOT)/include
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/common
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/xcelium
 CINCLUDES += -I$(BASEJUMP_STL_DIR)/bsg_mem
@@ -27,8 +32,8 @@ all:
 	@echo "## See the makefile for the fun things you can do in this directory"
 
 BUILD_LOG ?= build.log
-xcelium.d: $(HOST_PROGRAM) $(FLIST)
-	$(XRUN) $(XRUN_OPTS) $(CFLAGS) $(CINCLUDES) $< \
+xcelium.d: $(HOST_PROGRAM) $(FLIST) $(BUILD_COLLATERAL)
+	$(XRUN) $(XRUN_OPTS) $(CFLAGS) $(LDFLAGS) $(CINCLUDES) $< \
 		2>&1 | tee -i $(BUILD_LOG)
 
 RUN_LOG ?= run.log


### PR DESCRIPTION
This PR switches ZynqParrot to coroutine-based polling. This refactor doesn't add or remove functionality, but it does stop random crashing with proprietary simulators which are not thread-safe