### PR TITLE
Coroutines fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ boost/
 .Xil/
 bsg_bootrom.*
 NA/
+xrun.key
+

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ bsg_manycore_machine.h
 boost/
 .Xil/
 bsg_bootrom.*
+NA/

--- a/cosim/black-parrot-example/v/bp_common_pkg.sv
+++ b/cosim/black-parrot-example/v/bp_common_pkg.sv
@@ -48,9 +48,59 @@ package bp_common_pkg;
                         ,bp_default_cfg_p
                         );
 
+  localparam bp_proc_param_s bp_multicore_zynqparrot_cfg_override_p =
+    '{paddr_width: 34
+      ,cce_type : e_cce_fsm
+      ,ic_y_dim : 1
+
+      ,icache_fill_width: 64
+
+      ,dcache_fill_width: 64
+
+      ,acache_fill_width: 64
+
+      ,bedrock_fill_width: 64
+
+      ,coh_noc_flit_width : 64
+      ,mem_noc_flit_width : 64
+      ,dma_noc_flit_width : 64
+
+      ,icache_features      : (1 << e_cfg_enabled) | (1 << e_cfg_coherent)
+                              | (1 << e_cfg_misaligned)
+      ,dcache_features      : (1 << e_cfg_enabled)
+                              | (1 << e_cfg_coherent)
+                              | (1 << e_cfg_writeback)
+                              | (1 << e_cfg_lr_sc)
+                              | (1 << e_cfg_amo_swap)
+                              | (1 << e_cfg_amo_fetch_logic)
+                              | (1 << e_cfg_amo_fetch_arithmetic)
+      ,l2_features          : (1 << e_cfg_enabled) | (1 << e_cfg_writeback)
+                              | (1 << e_cfg_word_tracking)
+
+      ,l2_data_width: 64
+      ,l2_fill_width: 64
+      ,l2_slices    : 1
+      ,l2_banks     : 1
+
+      ,itlb_els_4k : 16
+      ,itlb_els_2m : 1
+      ,itlb_els_1g : 1
+      ,dtlb_els_4k : 16
+      ,dtlb_els_2m : 4
+      ,dtlb_els_1g : 1
+
+      ,default : "inv"
+      };
+  `bp_aviary_derive_cfg(bp_multicore_zynqparrot_cfg_p
+                        ,bp_multicore_zynqparrot_cfg_override_p
+                        ,bp_default_cfg_p
+                        );
+
+
   parameter bp_proc_param_s [max_cfgs-1:0] all_cfgs_gp =
   {
-    bp_unicore_zynqparrot_cfg_p
+    bp_multicore_zynqparrot_cfg_p
+    ,bp_unicore_zynqparrot_cfg_p
 
     // A custom BP configuration generated from Makefile
     ,bp_custom_cfg_p
@@ -61,7 +111,8 @@ package bp_common_pkg;
   // This enum MUST be kept up to date with the parameter array above
   typedef enum bit [lg_max_cfgs-1:0]
   {
-    e_bp_unicore_zynqparrot_cfg                     = 2
+    e_bp_multicore_zynqparrot_cfg                   = 3
+    ,e_bp_unicore_zynqparrot_cfg                    = 2
 
     // A custom BP configuration generated from `defines
     ,e_bp_custom_cfg                                = 1

--- a/cosim/black-parrot-example/v/top_zynq.sv
+++ b/cosim/black-parrot-example/v/top_zynq.sv
@@ -374,7 +374,7 @@ module top_zynq
    // to increment the counters.
    //
    if (cce_type_p != e_cce_uce)
-     assign minstret_lo = blackparrot.processor.m.multicore.cc.y[0].x[0].tile_node.tile_node.tile.core.core_lite.core_minimal.be.calculator.pipe_sys.csr.minstret_lo;
+     assign minstret_lo = blackparrot.processor.m.multicore.cc.y[0].x[0].tile_node.tile.core.core_lite.core_minimal.be.calculator.pipe_sys.csr.minstret_lo;
    else
      assign minstret_lo = blackparrot.processor.u.unicore.unicore_lite.core_minimal.be.calculator.pipe_sys.csr.minstret_lo;
 

--- a/cosim/black-parrot-example/v/top_zynq.sv
+++ b/cosim/black-parrot-example/v/top_zynq.sv
@@ -697,8 +697,6 @@ module top_zynq
       ,.axi_addr_width_p(bp_axi_addr_width_lp)
       ,.axi_data_width_p(bp_axi_data_width_lp)
       ,.axi_id_width_p(6)
-      ,.axi_size_width_p(3)
-      ,.axi_len_width_p(4)
       ,.axi_core_clk_async_p(0)
       )
    blackparrot

--- a/cosim/black-parrot-minimal-example/ps.cpp
+++ b/cosim/black-parrot-minimal-example/ps.cpp
@@ -212,7 +212,7 @@ int ps_main(int argc, char **argv) {
     buf = (volatile int32_t *)zpl->allocate_dram(allocated_dram, &phys_ptr);
     bsg_pr_info("ps.cpp: received %p (phys = %lx)\n", buf, phys_ptr);
     zpl->shell_write(GP0_WR_CSR_DRAM_BASE, phys_ptr, mask1);
-    assert((zpl->shell_read(GP0_RD_CSR_DRAM_BASE) == (phys_ptr)));
+    assert((zpl->shell_read(GP0_RD_CSR_DRAM_BASE) == (int32_t)(phys_ptr)));
     bsg_pr_info("ps.cpp: wrote and verified base register\n");
     zpl->shell_write(GP0_RD_CSR_DRAM_INITED, 1, mask1);
     assert(zpl->shell_read(GP0_RD_CSR_DRAM_INITED) == 1);

--- a/cosim/hammerblade-example/Makefile.design
+++ b/cosim/hammerblade-example/Makefile.design
@@ -38,7 +38,7 @@ $(CURR_VSRC_DIR)/bsg_blackparrot_pkg.sv:
 	echo "endpackage" >> $@
 	echo >> $@
 
-$(CURR_VSRC_DIR)/bsg_bladerunner_pkg.sv: $(BSG_MACHINE_PATH)/bsg_bladerunner_pkg.v
+$(CURR_VSRC_DIR)/bsg_bladerunner_pkg.sv: $(BSG_MACHINE_PATH)/bsg_bladerunner_pkg.sv
 	cp $< $@
 	$(SED) -i "/parameter int bsg_machine_hetero_type_vec_gp/d" $@
 

--- a/cosim/hammerblade-example/ps.cpp
+++ b/cosim/hammerblade-example/ps.cpp
@@ -164,7 +164,7 @@ int ps_main(int argc, char **argv) {
   buf = (volatile int32_t *)zpl->allocate_dram(allocated_dram, &phys_ptr);
   bsg_pr_info("ps.cpp: received %p (phys = %lx)\n", buf, phys_ptr);
   zpl->shell_write(GP0_WR_CSR_DRAM_BASE, phys_ptr, 0xf);
-  assert((zpl->shell_read(GP0_RD_CSR_DRAM_BASE) == phys_ptr));
+  assert((zpl->shell_read(GP0_RD_CSR_DRAM_BASE) == (int32_t)phys_ptr));
   bsg_pr_info("ps.cpp: wrote and verified base register\n");
 
   if (argc == 1) {

--- a/cosim/hammerblade-example/v/bp_common_pkg.sv
+++ b/cosim/hammerblade-example/v/bp_common_pkg.sv
@@ -40,13 +40,6 @@ package bp_common_pkg;
 
       ,l2_features          : 0
 
-      ,itlb_els_4k 			: 16
-      ,itlb_els_2m 			: 0
-      ,itlb_els_1g 			: 0
-      ,dtlb_els_4k 			: 16
-      ,dtlb_els_2m 			: 4
-      ,dtlb_els_1g 			: 0
-
       // Used for carrying payload of return packets
       ,mem_noc_did_width    : 19
       ,default : "inv"

--- a/cosim/hammerblade-example/v/top_zynq.sv
+++ b/cosim/hammerblade-example/v/top_zynq.sv
@@ -339,9 +339,9 @@ module top_zynq
      ,.num_subarray_y_p(bsg_machine_pod_tiles_subarray_y_gp)
 
      ,.dmem_size_p(bsg_machine_core_dmem_words_gp)
-     ,.icache_entries_p(bsg_machine_core_icache_entries_gp)
-     ,.icache_tag_width_p(bsg_machine_core_icache_tag_width_gp)
-     ,.icache_block_size_in_words_p(bsg_machine_core_icache_line_words_gp)
+     ,.mc_icache_entries_p(bsg_machine_core_icache_entries_gp)
+     ,.mc_icache_tag_width_p(bsg_machine_core_icache_tag_width_gp)
+     ,.mc_icache_block_size_in_words_p(bsg_machine_core_icache_line_words_gp)
 
      ,.vcache_addr_width_p(bsg_machine_llcache_addr_width_lp)
      ,.vcache_data_width_p(bsg_machine_llcache_data_width_lp)

--- a/cosim/include/common/bsg_axil.h
+++ b/cosim/include/common/bsg_axil.h
@@ -153,6 +153,7 @@ template <unsigned int A, unsigned int D> class axilm {
             while (!ar_done) {
                 if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
                     bsg_pr_err("bsg_zynq_pl: AXI M read arready timeout\n");
+                    timeout_counter = 0;
                 }
 
                 if (this->p_arready == 1) {
@@ -168,6 +169,7 @@ template <unsigned int A, unsigned int D> class axilm {
             while (!r_done) {
                 if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
                     bsg_pr_err("bsg_zynq_pl: AXI M read rvalid timeout\n");
+                    timeout_counter = 0;
                 }
 
                 if (this->p_rvalid == 1) {
@@ -210,6 +212,7 @@ template <unsigned int A, unsigned int D> class axilm {
                 // check timeout
                 if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
                     bsg_pr_err("bsg_zynq_pl: AXI S write timeout\n");
+                    timeout_counter = 0;
                 }
 
                 if (this->p_awready == 1) {
@@ -230,6 +233,7 @@ template <unsigned int A, unsigned int D> class axilm {
             while (!b_done) {
                 if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
                     bsg_pr_err("bsg_zynq_pl: AXI M bvalid timeout\n");
+                    timeout_counter = 0;
                 }
 
                 if (this->p_bvalid == 1) {
@@ -316,6 +320,7 @@ template <unsigned int A, unsigned int D> class axils {
             while (!ar_done) {
                 if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
                     bsg_pr_err("bsg_zynq_pl: AXI S read request timeout\n");
+                    timeout_counter = 0;
                 }
 
                 if (this->p_arvalid == 1) {
@@ -335,6 +340,7 @@ template <unsigned int A, unsigned int D> class axils {
             while (!r_done) {
                 if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
                     bsg_pr_err("bsg_zynq_pl: AXI S read data timeout\n");
+                    timeout_counter = 0;
                 }
 
                 if (this->p_rready == 1) {
@@ -364,6 +370,7 @@ template <unsigned int A, unsigned int D> class axils {
             while (!aw_done || !w_done) {
                 if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
                     bsg_pr_err("bsg_zynq_pl: AXI S write timeout\n");
+                    timeout_counter = 0;
                 }
 
                 if (this->p_awvalid) {
@@ -393,6 +400,7 @@ template <unsigned int A, unsigned int D> class axils {
             while (!b_done) {
                 if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
                     bsg_pr_err("bsg_zynq_pl: AXI S bvalid timeout\n");
+                    timeout_counter = 0;
                 }
 
                 if (this->p_bready == 1) {

--- a/cosim/include/common/bsg_axil.h
+++ b/cosim/include/common/bsg_axil.h
@@ -10,26 +10,37 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <svdpi.h>
 #include <unistd.h>
 #include <string>
+
+#include <boost/coroutine2/all.hpp>
+
 #include "bsg_nonsynth_dpi_gpio.hpp"
 #include "bsg_printing.h"
 
 #ifndef ZYNQ_AXI_TIMEOUT
-#define ZYNQ_AXI_TIMEOUT 8000
+#define ZYNQ_AXI_TIMEOUT 1000
 #endif
 
+extern "C" { int bsg_dpi_time(); }
 using namespace std;
 using namespace bsg_nonsynth_dpi;
+using namespace boost::coroutines2;
+using namespace std::placeholders;
+
+typedef coroutine<void>::pull_type coro_t;
+typedef coroutine<void>::push_type yield_t;
 
 // W = width of pin
-template <unsigned int W> class pin {
-    std::unique_ptr<dpi_gpio<W> > gpio;
+template <unsigned int W>
+class pin {
+    std::unique_ptr<dpi_gpio<W>> gpio;
 
-    public:
+public:
     pin(const string &hierarchy) {
-        gpio = std::make_unique<dpi_gpio<W> >(hierarchy);
+        gpio = std::make_unique<dpi_gpio<W>>(hierarchy);
     }
 
     void set(const unsigned int val) {
@@ -40,9 +51,7 @@ template <unsigned int W> class pin {
         }
     }
 
-    void operator=(const unsigned int val) {
-        set(val);
-    }
+    void operator=(const unsigned int val) { set(val); }
 
     int get() const {
         unsigned int N = 0;
@@ -53,364 +62,455 @@ template <unsigned int W> class pin {
         return N;
     }
 
-    operator int() const {
-        return get();
-    }
+    operator int() const { return get(); }
 };
 
 class s_axil_device {
-    public:
-        virtual bool is_read(uintptr_t address) = 0;
-        virtual int32_t read(uintptr_t address) = 0;
+public:
+    virtual bool is_read(uintptr_t address) = 0;
+    virtual int32_t read(uintptr_t address) = 0;
 
-        virtual bool is_write(uintptr_t address) = 0;
-        virtual void write(uintptr_t address, int32_t data) = 0;
+    virtual bool is_write(uintptr_t address) = 0;
+    virtual void write(uintptr_t address, int32_t data) = 0;
 };
 
 class m_axil_device {
-    public:
-        virtual bool pending_read(uintptr_t *address) = 0;
-        virtual void return_read(int32_t data) = 0;
+public:
+    virtual bool pending_read(uintptr_t *address) = 0;
+    virtual void return_read(int32_t data) = 0;
 
-        virtual bool pending_write(uintptr_t *address, int32_t *data, uint8_t *wmask) = 0;
-        virtual void return_write() = 0;
+    virtual bool pending_write(uintptr_t *address, int32_t *data,
+                               uint8_t *wmask) = 0;
+    virtual void return_write() = 0;
 };
 
 // A = axil address width
 // D = axil data width
-template <unsigned int A, unsigned int D> class axilm {
-    public:
-        pin<1> p_aclk;
-        pin<1> p_aresetn;
+template <unsigned int A, unsigned int D>
+class axilm {
+private:
+    string base;
 
-        pin<A> p_awaddr;
-        pin<3> p_awprot;
-        pin<1> p_awvalid;
-        pin<1> p_awready;
-        pin<D> p_wdata;
-        pin<D / 8> p_wstrb;
-        pin<1> p_wvalid;
-        pin<1> p_wready;
-        pin<2> p_bresp;
-        pin<1> p_bvalid;
-        pin<1> p_bready;
+    pin<1> p_aclk;
+    pin<1> p_aresetn;
 
-        pin<A> p_araddr;
-        pin<3> p_arprot;
-        pin<1> p_arvalid;
-        pin<1> p_arready;
-        pin<D> p_rdata;
-        pin<2> p_rresp;
-        pin<1> p_rvalid;
-        pin<1> p_rready;
+    pin<A> p_awaddr;
+    pin<3> p_awprot;
+    pin<1> p_awvalid;
+    pin<1> p_awready;
+    pin<D> p_wdata;
+    pin<D / 8> p_wstrb;
+    pin<1> p_wvalid;
+    pin<1> p_wready;
+    pin<2> p_bresp;
+    pin<1> p_bvalid;
+    pin<1> p_bready;
 
-        axilm(const string &base)
-            : p_aclk(string(base) + string(".aclk_gpio")),
-            p_aresetn(string(base) + string(".aresetn_gpio")),
-            p_awaddr(string(base) + string(".awaddr_gpio")),
-            p_awprot(string(base) + string(".awprot_gpio")),
-            p_awvalid(string(base) + string(".awvalid_gpio")),
-            p_awready(string(base) + string(".awready_gpio")),
-            p_wdata(string(base) + string(".wdata_gpio")),
-            p_wstrb(string(base) + string(".wstrb_gpio")),
-            p_wvalid(string(base) + string(".wvalid_gpio")),
-            p_wready(string(base) + string(".wready_gpio")),
-            p_bresp(string(base) + string(".bresp_gpio")),
-            p_bvalid(string(base) + string(".bvalid_gpio")),
-            p_bready(string(base) + string(".bready_gpio")),
-            p_araddr(string(base) + string(".araddr_gpio")),
-            p_arprot(string(base) + string(".arprot_gpio")),
-            p_arvalid(string(base) + string(".arvalid_gpio")),
-            p_arready(string(base) + string(".arready_gpio")),
-            p_rdata(string(base) + string(".rdata_gpio")),
-            p_rresp(string(base) + string(".rresp_gpio")),
-            p_rvalid(string(base) + string(".rvalid_gpio")),
-            p_rready(string(base) + string(".rready_gpio")) {
-                std::cout << "Instantiating AXIL at " << base << std::endl;
-            }
+    pin<A> p_araddr;
+    pin<3> p_arprot;
+    pin<1> p_arvalid;
+    pin<1> p_arready;
+    pin<D> p_rdata;
+    pin<2> p_rresp;
+    pin<1> p_rvalid;
+    pin<1> p_rready;
 
-        // Wait for (low true) reset to be asserted by the testbench
-        void reset(std::function<void()> tick) {
-            printf("bsg_zynq_pl: Entering reset\n");
-            while (this->p_aresetn == 0) {
-                tick();
-            }
-            printf("bsg_zynq_pl: Exiting reset\n");
+    // We use a boolean instead of true mutex so that we can check it
+    bool mutex;
+
+    void lock(yield_t &yield) {
+        do {
+            yield();
+        } while (mutex);
+        mutex = 1;
+    }
+
+    void unlock(yield_t &yield) {
+        yield();
+        mutex = 0;
+    }
+
+public:
+    axilm(const string &base)
+        : base(base),
+          p_aclk(string(base) + string(".aclk_gpio")),
+          p_aresetn(string(base) + string(".aresetn_gpio")),
+          p_awaddr(string(base) + string(".awaddr_gpio")),
+          p_awprot(string(base) + string(".awprot_gpio")),
+          p_awvalid(string(base) + string(".awvalid_gpio")),
+          p_awready(string(base) + string(".awready_gpio")),
+          p_wdata(string(base) + string(".wdata_gpio")),
+          p_wstrb(string(base) + string(".wstrb_gpio")),
+          p_wvalid(string(base) + string(".wvalid_gpio")),
+          p_wready(string(base) + string(".wready_gpio")),
+          p_bresp(string(base) + string(".bresp_gpio")),
+          p_bvalid(string(base) + string(".bvalid_gpio")),
+          p_bready(string(base) + string(".bready_gpio")),
+          p_araddr(string(base) + string(".araddr_gpio")),
+          p_arprot(string(base) + string(".arprot_gpio")),
+          p_arvalid(string(base) + string(".arvalid_gpio")),
+          p_arready(string(base) + string(".arready_gpio")),
+          p_rdata(string(base) + string(".rdata_gpio")),
+          p_rresp(string(base) + string(".rresp_gpio")),
+          p_rvalid(string(base) + string(".rvalid_gpio")),
+          p_rready(string(base) + string(".rready_gpio")) {
+        std::cout << "Instantiating AXIL at " << base << std::endl;
+    }
+
+    // Wait for (low true) reset to be asserted by the testbench
+    void reset(yield_t &yield) {
+        printf("bsg_zynq_pl: Entering reset\n");
+        lock(yield);
+        while (this->p_aresetn == 0) {
+            yield();
         }
+        unlock(yield);
+        printf("bsg_zynq_pl: Exiting reset\n");
+    }
 
-        int axil_read_helper(uintptr_t address, std::function<void()> tick) {
-            int timeout_counter = 0;
+    int32_t axil_read_helper(uintptr_t address, yield_t &yield) {
+        lock(yield);
+        int timeout_counter = 0;
 
-            bool ar_done = false;
-            bool r_done = false;
+        bool ar_done = false;
+        bool r_done = false;
 
-            int rdata;
+        int rdata;
 
-            // assert these signals "late in the cycle"
-            // stall while ready is not asserted
-            this->p_arvalid = 1;
-            this->p_araddr = address;
-            while (!ar_done) {
-                if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
-                    bsg_pr_err("bsg_zynq_pl: AXI M read arready timeout\n");
-                    timeout_counter = 0;
-                }
-
-                if (this->p_arready == 1) {
-                    ar_done = true;
-                }
-
-                tick();
-            }
-            this->p_arvalid = 0;
-
-            // setup to receive the reply
-            // stall while valid is not asserted
-            while (!r_done) {
-                if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
-                    bsg_pr_err("bsg_zynq_pl: AXI M read rvalid timeout\n");
-                    timeout_counter = 0;
-                }
-
-                if (this->p_rvalid == 1) {
-                    rdata = this->p_rdata;
-                    r_done = true;
-                }
-
-                tick();
+        // assert these signals "late in the cycle"
+        // stall while ready is not asserted
+        this->p_arvalid = 1;
+        this->p_araddr = address;
+        do {
+            if (timeout_counter++ == ZYNQ_AXI_TIMEOUT) {
+                bsg_pr_err("bsg_zynq_pl: AXI M read arready timeout\n");
+                timeout_counter = 0;
             }
 
-            // Do the read
-            this->p_rready = 1;
-            tick();
-            this->p_rready = 0;
-
-            return rdata;
-        }
-
-        void axil_write_helper(uintptr_t address, int32_t data, uint8_t wstrb,
-                std::function<void()> tick) {
-            int timeout_counter = 0;
-
-            assert(wstrb == 0xf); // we only support full int writes right now
-
-            bool aw_done = false;
-            bool w_done = false;
-            bool b_done = false;
-
-            // send data and address in same cycle
-            this->p_awvalid = 1;
-            this->p_wvalid = 1;
-            this->p_awaddr = address;
-            this->p_wdata = data;
-            this->p_wstrb = wstrb;
-
-            // loop until both address and data consumed
-            // subordinate is allowed to consume one before the other, or both at once
-            // this loop will run at least once (and tick the clock)
-            while (!aw_done || !w_done) {
-                // check timeout
-                if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
-                    bsg_pr_err("bsg_zynq_pl: AXI M write timeout\n");
-                    timeout_counter = 0;
-                }
-
-                if (this->p_awready == 1) {
-                    aw_done = true;
-                }
-
-                if (this->p_wready == 1) {
-                    w_done = true;
-                }
-
-                // tick the clock one cycle
-                tick();
+            if (this->p_arready == 1) {
+                ar_done = true;
             }
-            this->p_awvalid = 0;
-            this->p_wvalid = 0;
+            yield();
 
-            // wait for response valid
-            while (!b_done) {
-                if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
-                    bsg_pr_err("bsg_zynq_pl: AXI M bvalid timeout\n");
-                    timeout_counter = 0;
-                }
-
-                if (this->p_bvalid == 1) {
-                    this->p_bready = 1;
-                    b_done = true;
-                }
-
-                tick();
+            if (ar_done) {
+                this->p_arvalid = 0;
             }
-            // Drop bready
-            this->p_bready = 0;
-        }
+        } while (!ar_done);
+
+        // setup to receive the reply
+        // stall while valid is not asserted
+        yield();
+        this->p_rready = 1;
+        do {
+            if (timeout_counter++ == ZYNQ_AXI_TIMEOUT) {
+                bsg_pr_err("bsg_zynq_pl: AXI M read rvalid timeout\n");
+                timeout_counter = 0;
+            }
+
+            if (this->p_rvalid == 1) {
+                rdata = this->p_rdata;
+                r_done = true;
+            }
+            yield();
+
+            if (r_done) {
+                this->p_rready = 0;
+            }
+        } while (!r_done);
+
+        unlock(yield);
+        return rdata;
+    }
+
+    void axil_write_helper(uintptr_t address, int32_t data, uint8_t wstrb,
+                           yield_t &yield) {
+        lock(yield);
+        int timeout_counter = 0;
+
+        bool aw_done = false;
+        bool w_done = false;
+        bool b_done = false;
+
+        // loop until both address and data consumed
+        // subordinate is allowed to consume one before the other, or both at
+        // once
+        // this loop will run at least once (and tick the clock)
+        // send data and address in same cycle
+        this->p_awvalid = 1;
+        this->p_wvalid = 1;
+        this->p_awaddr = address;
+        this->p_wdata = data;
+        this->p_wstrb = wstrb;
+        do {
+            // check timeout
+            if (timeout_counter++ == ZYNQ_AXI_TIMEOUT) {
+                bsg_pr_err("bsg_zynq_pl: AXI M write timeout\n");
+            }
+
+            if (this->p_awready == 1) {
+                aw_done = true;
+            }
+
+            if (this->p_wready == 1) {
+                w_done = true;
+            }
+
+            // tick the clock one cycle
+            yield();
+
+            if (aw_done) {
+                this->p_awvalid = 0;
+            }
+
+            if (w_done) {
+                this->p_wvalid = 0;
+            }
+        } while (!aw_done || !w_done);
+
+        yield();
+        this->p_bready = 1;
+        do {
+            if (timeout_counter++ == ZYNQ_AXI_TIMEOUT) {
+                bsg_pr_err("bsg_zynq_pl: %s, AXI M bvalid timeout at %lld\n,",
+                           base.c_str(), bsg_dpi_time());
+            }
+
+            if (this->p_bvalid == 1) {
+                b_done = true;
+            }
+
+            yield();
+
+            if (b_done) {
+                this->p_bready = 0;
+            }
+        } while (!b_done);
+
+        unlock(yield);
+        return;
+    }
 };
 
 // A = axil address width
 // D = axil data width
-template <unsigned int A, unsigned int D> class axils {
-    public:
-        pin<1> p_aclk;
-        pin<1> p_aresetn;
+template <unsigned int A, unsigned int D>
+class axils {
+private:
+    pin<1> p_aclk;
+    pin<1> p_aresetn;
 
-        pin<A> p_awaddr;
-        pin<3> p_awprot;
-        pin<1> p_awvalid;
-        pin<1> p_awready;
-        pin<D> p_wdata;
-        pin<D / 8> p_wstrb;
-        pin<1> p_wvalid;
-        pin<1> p_wready;
-        pin<2> p_bresp;
-        pin<1> p_bvalid;
-        pin<1> p_bready;
+    pin<A> p_awaddr;
+    pin<3> p_awprot;
+    pin<1> p_awvalid;
+    pin<1> p_awready;
+    pin<D> p_wdata;
+    pin<D / 8> p_wstrb;
+    pin<1> p_wvalid;
+    pin<1> p_wready;
+    pin<2> p_bresp;
+    pin<1> p_bvalid;
+    pin<1> p_bready;
 
-        pin<A> p_araddr;
-        pin<3> p_arprot;
-        pin<1> p_arvalid;
-        pin<1> p_arready;
-        pin<D> p_rdata;
-        pin<2> p_rresp;
-        pin<1> p_rvalid;
-        pin<1> p_rready;
+    pin<A> p_araddr;
+    pin<3> p_arprot;
+    pin<1> p_arvalid;
+    pin<1> p_arready;
+    pin<D> p_rdata;
+    pin<2> p_rresp;
+    pin<1> p_rvalid;
+    pin<1> p_rready;
 
-        axils(const string &base)
-            : p_aclk(string(base) + string(".aclk_gpio")),
-            p_aresetn(string(base) + string(".aresetn_gpio")),
-            p_awaddr(string(base) + string(".awaddr_gpio")),
-            p_awprot(string(base) + string(".awprot_gpio")),
-            p_awvalid(string(base) + string(".awvalid_gpio")),
-            p_awready(string(base) + string(".awready_gpio")),
-            p_wdata(string(base) + string(".wdata_gpio")),
-            p_wstrb(string(base) + string(".wstrb_gpio")),
-            p_wvalid(string(base) + string(".wvalid_gpio")),
-            p_wready(string(base) + string(".wready_gpio")),
-            p_bresp(string(base) + string(".bresp_gpio")),
-            p_bvalid(string(base) + string(".bvalid_gpio")),
-            p_bready(string(base) + string(".bready_gpio")),
-            p_araddr(string(base) + string(".araddr_gpio")),
-            p_arprot(string(base) + string(".arprot_gpio")),
-            p_arvalid(string(base) + string(".arvalid_gpio")),
-            p_arready(string(base) + string(".arready_gpio")),
-            p_rdata(string(base) + string(".rdata_gpio")),
-            p_rresp(string(base) + string(".rresp_gpio")),
-            p_rvalid(string(base) + string(".rvalid_gpio")),
-            p_rready(string(base) + string(".rready_gpio")) {
-                std::cout << "Instantiating AXIL at " << base << std::endl;
-            }
+    // We use a boolean instead of true mutex so that we can check it
+    bool mutex;
 
-        // Wait for (low true) reset to be asserted by the testbench
-        void reset(std::function<void()> tick) {
-            printf("bsg_zynq_pl: Entering reset\n");
-            while (this->p_aresetn == 0) {
-                tick();
-            }
-            printf("bsg_zynq_pl: Exiting reset\n");
+    void lock(yield_t &yield) {
+        do {
+            yield();
+        } while (mutex);
+        mutex = 1;
+    }
+
+    void unlock(yield_t &yield) {
+        yield();
+        mutex = 0;
+    }
+
+public:
+    axils(const string &base)
+        : p_aclk(string(base) + string(".aclk_gpio")),
+          p_aresetn(string(base) + string(".aresetn_gpio")),
+          p_awaddr(string(base) + string(".awaddr_gpio")),
+          p_awprot(string(base) + string(".awprot_gpio")),
+          p_awvalid(string(base) + string(".awvalid_gpio")),
+          p_awready(string(base) + string(".awready_gpio")),
+          p_wdata(string(base) + string(".wdata_gpio")),
+          p_wstrb(string(base) + string(".wstrb_gpio")),
+          p_wvalid(string(base) + string(".wvalid_gpio")),
+          p_wready(string(base) + string(".wready_gpio")),
+          p_bresp(string(base) + string(".bresp_gpio")),
+          p_bvalid(string(base) + string(".bvalid_gpio")),
+          p_bready(string(base) + string(".bready_gpio")),
+          p_araddr(string(base) + string(".araddr_gpio")),
+          p_arprot(string(base) + string(".arprot_gpio")),
+          p_arvalid(string(base) + string(".arvalid_gpio")),
+          p_arready(string(base) + string(".arready_gpio")),
+          p_rdata(string(base) + string(".rdata_gpio")),
+          p_rresp(string(base) + string(".rresp_gpio")),
+          p_rvalid(string(base) + string(".rvalid_gpio")),
+          p_rready(string(base) + string(".rready_gpio")) {
+        std::cout << "Instantiating AXIL at " << base << std::endl;
+    }
+
+    // Wait for (low true) reset to be asserted by the testbench
+    void reset(yield_t &yield) {
+        printf("bsg_zynq_pl: Entering reset\n");
+        lock(yield);
+        while (this->p_aresetn == 0) {
+            yield();
         }
+        unlock(yield);
+        printf("bsg_zynq_pl: Exiting reset\n");
+    }
 
-        void axil_read_helper(s_axil_device *p, std::function<void()> tick) {
-            int timeout_counter = 0;
-            int araddr;
+    bool axil_has_write(uintptr_t *address) {
+        bool awv = this->p_awvalid;
+        bool wv = this->p_wvalid;
+        *address = this->p_awaddr;
+        return awv && wv && !mutex;
+    }
 
-            bool ar_done = false;
-            bool r_done = false;
+    bool axil_has_read(uintptr_t *address) {
+        bool arv = this->p_arvalid;
+        *address = this->p_araddr;
+        return arv && !mutex;
+    }
 
-            while (!ar_done) {
-                if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
-                    bsg_pr_err("bsg_zynq_pl: AXI S read request timeout\n");
-                    timeout_counter = 0;
-                }
+    void axil_read_helper(s_axil_device *p, yield_t &yield) {
+        lock(yield);
+        int timeout_counter = 0;
+        int araddr;
 
-                if (this->p_arvalid == 1) {
-                    araddr = this->p_araddr;
-                    this->p_arready = 1;
-                    ar_done = true;
-                }
+        bool ar_done = false;
+        bool r_done = false;
 
-                tick();
-            }
-            this->p_arready = 0;
-
-            // Return read data
-            this->p_rdata = p->read(araddr);
-            this->p_rresp = 0;
-            this->p_rvalid = 1;
-            while (!r_done) {
-                if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
-                    bsg_pr_err("bsg_zynq_pl: AXI S read data timeout\n");
-                    timeout_counter = 0;
-                }
-
-                if (this->p_rready == 1) {
-                    r_done = true;
-                }
-
-                tick();
-            }
-            this->p_rvalid = 0;
-        }
-
-        void axil_write_helper(s_axil_device *p, std::function<void ()> tick) {
-            int timeout_counter = 0;
-
-            bool aw_done = false;
-            bool w_done = false;
-            bool b_done = false;
-
-            assert(this->p_wstrb == 0xf); // we only support full int writes right now
-
-            int awaddr;
-            int wdata;
-
-            // loop until both address and data consumed
-            // subordinate is allowed to consume one before the other, or both at once
-            // this loop will run at least once (and tick the clock)
-            while (!aw_done || !w_done) {
-                if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
-                    bsg_pr_err("bsg_zynq_pl: AXI S write timeout\n");
-                    timeout_counter = 0;
-                }
-
-                if (this->p_awvalid) {
-                    awaddr = this->p_awaddr;
-                    this->p_awready = 1;
-                    aw_done = true;
-                }
-
-                if (this->p_wvalid) {
-                    wdata = this->p_wdata;
-                    this->p_wready = 1;
-                    w_done = true;
-                }
-
-                tick();
+        this->p_arready = 1;
+        do {
+            if (timeout_counter++ == ZYNQ_AXI_TIMEOUT) {
+                bsg_pr_err("bsg_zynq_pl: AXI S read request timeout\n");
+                timeout_counter = 0;
             }
 
-            // Do the write
-            p->write(awaddr, wdata);
-            this->p_awready = 0;
-            this->p_wready = 0;
-
-            // raise bvalid for response
-            // wait for response ready
-            this->p_bvalid = 1;
-            this->p_bresp  = 0;
-            while (!b_done) {
-                if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
-                    bsg_pr_err("bsg_zynq_pl: AXI S bvalid timeout\n");
-                    timeout_counter = 0;
-                }
-
-                if (this->p_bready == 1) {
-                    b_done = true;
-                }
-
-                tick();
+            if (this->p_arvalid == 1) {
+                araddr = this->p_araddr;
+                ar_done = true;
             }
-            this->p_bvalid = 0;
-        }
+
+            yield();
+
+            if (ar_done) {
+                this->p_arready = 0;
+            }
+        } while (!ar_done);
+
+        // Return read data
+        yield();
+        this->p_rdata = p->read(araddr);
+        this->p_rresp = 0;
+        this->p_rvalid = 1;
+        do {
+            if (timeout_counter++ == ZYNQ_AXI_TIMEOUT) {
+                bsg_pr_err("bsg_zynq_pl: AXI S read data timeout\n");
+                timeout_counter = 0;
+            }
+
+            if (this->p_rready == 1) {
+                r_done = true;
+            }
+
+            yield();
+
+            if (r_done) {
+                this->p_rvalid = 0;
+            }
+        } while (!r_done);
+        unlock(yield);
+        return;
+    }
+
+    void axil_write_helper(s_axil_device *p, yield_t &yield) {
+        lock(yield);
+        int timeout_counter = 0;
+
+        bool aw_done = false;
+        bool w_done = false;
+        bool b_done = false;
+
+        int awaddr;
+        int wdata;
+
+        // loop until both address and data consumed
+        // subordinate is allowed to consume one before the other, or both at
+        // once
+        // this loop will run at least once (and tick the clock)
+        this->p_awready = 1;
+        this->p_wready = 1;
+        do {
+            if (timeout_counter++ == ZYNQ_AXI_TIMEOUT) {
+                bsg_pr_err("bsg_zynq_pl: AXI S write timeout\n");
+                timeout_counter = 0;
+            }
+
+            if (this->p_awvalid) {
+                awaddr = this->p_awaddr;
+                aw_done = true;
+            }
+
+            if (this->p_wvalid) {
+                wdata = this->p_wdata;
+                w_done = true;
+            }
+
+            yield();
+
+            if (aw_done) {
+                this->p_awready = 0;
+            }
+
+            if (w_done) {
+                this->p_wready = 0;
+            }
+
+            if (aw_done && w_done) {
+                // Do the write
+                p->write(awaddr, wdata);
+            }
+        } while (!aw_done || !w_done);
+
+        // raise bvalid for response
+        // wait for response ready
+        yield();
+        this->p_bvalid = 1;
+        this->p_bresp = 0;
+        do {
+            if (timeout_counter++ == ZYNQ_AXI_TIMEOUT) {
+                bsg_pr_err("bsg_zynq_pl: AXI S bvalid timeout\n");
+                timeout_counter = 0;
+            }
+
+            if (this->p_bready == 1) {
+                b_done = true;
+            }
+
+            yield();
+
+            if (b_done) {
+                this->p_bvalid = 0;
+            }
+        } while (!b_done);
+
+        unlock(yield);
+        return;
+    }
 };
 
 #endif

--- a/cosim/include/common/bsg_axil.h
+++ b/cosim/include/common/bsg_axil.h
@@ -211,7 +211,7 @@ template <unsigned int A, unsigned int D> class axilm {
             while (!aw_done || !w_done) {
                 // check timeout
                 if (timeout_counter++ > ZYNQ_AXI_TIMEOUT) {
-                    bsg_pr_err("bsg_zynq_pl: AXI S write timeout\n");
+                    bsg_pr_err("bsg_zynq_pl: AXI M write timeout\n");
                     timeout_counter = 0;
                 }
 

--- a/cosim/include/common/bsg_axil.h
+++ b/cosim/include/common/bsg_axil.h
@@ -116,7 +116,7 @@ private:
     pin<1> p_rready;
 
     // We use a boolean instead of true mutex so that we can check it
-    bool mutex;
+    bool mutex = 0;
 
     void lock(yield_t &yield) {
         do {
@@ -153,7 +153,8 @@ public:
           p_rdata(string(base) + string(".rdata_gpio")),
           p_rresp(string(base) + string(".rresp_gpio")),
           p_rvalid(string(base) + string(".rvalid_gpio")),
-          p_rready(string(base) + string(".rready_gpio")) {
+          p_rready(string(base) + string(".rready_gpio")),
+          mutex(0) {
         std::cout << "Instantiating AXIL at " << base << std::endl;
     }
 
@@ -321,7 +322,7 @@ private:
     pin<1> p_rready;
 
     // We use a boolean instead of true mutex so that we can check it
-    bool mutex;
+    bool mutex = 0;
 
     void lock(yield_t &yield) {
         do {

--- a/cosim/include/common/bsg_peripherals.h
+++ b/cosim/include/common/bsg_peripherals.h
@@ -11,28 +11,32 @@
 class zynq_scratchpad : public s_axil_device {
     std::vector<int32_t> mem;
 
-    public:
-    zynq_scratchpad() {
-        mem.resize(SCRATCHPAD_SIZE, 0);
-    }
+public:
+    zynq_scratchpad() { mem.resize(SCRATCHPAD_SIZE, 0); }
 
     bool is_read(uintptr_t address) override {
-        return (address >= SCRATCHPAD_BASE) && (address < SCRATCHPAD_BASE+SCRATCHPAD_SIZE);
+        return (address >= SCRATCHPAD_BASE) &&
+               (address < SCRATCHPAD_BASE + SCRATCHPAD_SIZE);
     }
 
     bool is_write(uintptr_t address) override {
-        return (address >= SCRATCHPAD_BASE) && (address < SCRATCHPAD_BASE+SCRATCHPAD_SIZE);
+        return (address >= SCRATCHPAD_BASE) &&
+               (address < SCRATCHPAD_BASE + SCRATCHPAD_SIZE);
     }
 
     int32_t read(uintptr_t address) override {
-        uintptr_t final_addr = ((address-SCRATCHPAD_BASE) + SCRATCHPAD_SIZE) % SCRATCHPAD_SIZE;
-        bsg_pr_dbg_pl("  bsg_zynq_pl: scratchpad read [%x] == %x\n", final_addr, mem.at(final_addr));
+        uintptr_t final_addr =
+            ((address - SCRATCHPAD_BASE) + SCRATCHPAD_SIZE) % SCRATCHPAD_SIZE;
+        bsg_pr_dbg_pl("  bsg_zynq_pl: scratchpad read [%x] == %x\n", final_addr,
+                      mem.at(final_addr));
         return mem.at(final_addr);
     }
 
     void write(uintptr_t address, int32_t data) override {
-        int final_addr = ((address-SCRATCHPAD_BASE) + SCRATCHPAD_SIZE) % SCRATCHPAD_SIZE;
-        bsg_pr_dbg_pl("  bsg_zynq_pl: scratchpad write [%x] <- %x\n", final_addr, data);
+        int final_addr =
+            ((address - SCRATCHPAD_BASE) + SCRATCHPAD_SIZE) % SCRATCHPAD_SIZE;
+        bsg_pr_dbg_pl("  bsg_zynq_pl: scratchpad write [%x] <- %x\n",
+                      final_addr, data);
         mem.at(final_addr) = data;
     }
 };
@@ -42,26 +46,26 @@ class zynq_scratchpad : public s_axil_device {
 #define UART_SIZE 0x1000
 #define UART_REG_RX_FIFO 0x000
 #define UART_REG_TX_FIFO 0x004
-#define UART_REG_STAT    0x008
-#define UART_REG_CTRL    0x00c
+#define UART_REG_STAT 0x008
+#define UART_REG_CTRL 0x00c
 class zynq_uart : public s_axil_device {
     std::queue<uint8_t> rx_fifo;
     std::queue<uint8_t> tx_fifo;
 
-    public:
-    zynq_uart() { }
+public:
+    zynq_uart() {}
 
     bool is_read(uintptr_t address) override {
-        return (address >= UART_BASE) && (address < UART_BASE+UART_SIZE);
+        return (address >= UART_BASE) && (address < UART_BASE + UART_SIZE);
     }
 
     bool is_write(uintptr_t address) override {
 
-        return (address >= UART_BASE) && (address < UART_BASE+UART_SIZE);
+        return (address >= UART_BASE) && (address < UART_BASE + UART_SIZE);
     }
 
     int32_t read(uintptr_t address) override {
-        uintptr_t final_addr = ((address-UART_BASE) + UART_SIZE) % UART_SIZE;
+        uintptr_t final_addr = ((address - UART_BASE) + UART_SIZE) % UART_SIZE;
         int32_t retval = 0;
         if (final_addr == UART_REG_RX_FIFO) {
             if (!rx_fifo.empty()) {
@@ -69,64 +73,76 @@ class zynq_uart : public s_axil_device {
                 rx_fifo.pop();
             }
         } else if (final_addr == UART_REG_STAT) {
-            retval = ((1 & tx_fifo.empty()) << 2)     // TX empty
-                | ((1 & !rx_fifo.empty()) << 0); // RX valid
+            retval = ((1 & tx_fifo.empty()) << 2)      // TX empty
+                     | ((1 & !rx_fifo.empty()) << 0);  // RX valid
         } else {
             bsg_pr_info("  bsg_zynq_pl: errant uart read: %x\n", final_addr);
         }
 
-        bsg_pr_dbg_pl("  bsg_zynq_pl: uart read [%x] == %x\n", final_addr, retval);
+        bsg_pr_dbg_pl("  bsg_zynq_pl: uart read [%x] == %x\n", final_addr,
+                      retval);
         return retval;
     }
 
     void write(uintptr_t address, int32_t data) override {
-        int final_addr = ((address-UART_BASE) + UART_SIZE) % UART_SIZE;
+        int final_addr = ((address - UART_BASE) + UART_SIZE) % UART_SIZE;
         if (final_addr == UART_REG_TX_FIFO) {
             tx_fifo.push(data);
         } else if (final_addr == UART_REG_CTRL) {
-            if (data & 0b00001) { // reset TX FIFO
-                while (!tx_fifo.empty()) { tx_fifo.pop(); }
-            } else if (data & 0xb00010) { // reset RX FIFO
-                while (!rx_fifo.empty()) { rx_fifo.pop(); }
+            if (data & 0b00001) {  // reset TX FIFO
+                while (!tx_fifo.empty()) {
+                    tx_fifo.pop();
+                }
+            } else if (data & 0xb00010) {  // reset RX FIFO
+                while (!rx_fifo.empty()) {
+                    rx_fifo.pop();
+                }
             } else {
-                bsg_pr_info("  bsg_zynq_pl: errant uart write: %x\n", final_addr);
+                bsg_pr_info("  bsg_zynq_pl: errant uart write: %x\n",
+                            final_addr);
             }
         } else {
             bsg_pr_info("  bsg_zynq_pl: errant uart write: %x\n", final_addr);
         }
 
-        bsg_pr_dbg_pl("  bsg_zynq_pl: uart write [%x] <- %x\n", final_addr, data);
+        bsg_pr_dbg_pl("  bsg_zynq_pl: uart write [%x] <- %x\n", final_addr,
+                      data);
     }
 
     // USER Functions
-    void tx_helper(uint8_t c, std::function<void ()> tick) {
-        bsg_pr_dbg_pl("  bsg_zynq_pl: uart tx %x \n", c);
+    bool tx_helper(uint8_t c) {
         rx_fifo.push(c);
-        tick();
+        bsg_pr_dbg_pl("  bsg_zynq_pl: uart tx %x \n", c);
+
+        return true;
     }
 
-    uint8_t rx_helper(std::function<void ()> tick) {
-        while (tx_fifo.empty()) { tick(); }
+    bool rx_helper(uint8_t *c) {
+        if (tx_fifo.empty()) {
+            return false;
+        };
 
-        uint8_t c = tx_fifo.front();
+        *c = tx_fifo.front();
         tx_fifo.pop();
-        bsg_pr_dbg_pl("  bsg_zynq_pl: uart rx %x \n", c);
+        bsg_pr_dbg_pl("  bsg_zynq_pl: uart rx %x \n", *c);
 
-        return c;
+        return true;
     }
 };
 
-#define WATCHDOG_ADDRESS 0x103000
-#define WATCHDOG_PERIOD  0x1000
-class zynq_watchdog : public m_axil_device {
+#define WATCHDOG_BASE 0x0F00000
+#define WATCHDOG_SIZE 0x0001000
+#define WATCHDOG_ADDRESS WATCHDOG_BASE
+#define WATCHDOG_PERIOD 0x10000
+class zynq_watchdog : public m_axil_device, public s_axil_device {
     int count = 0;
-    public:
+
+public:
     bool pending_write(uintptr_t *address, int32_t *data, uint8_t *wmask) {
         // Every time we check for pending, we increment the count
-        count++;
-        if (count % WATCHDOG_PERIOD == 0) {
+        if (count++ % WATCHDOG_PERIOD == 0) {
             *address = WATCHDOG_ADDRESS;
-            *data = 'W'; // For 'woof'
+            *data = 'W';  // For 'woof'
             *wmask = 0xf;
             bsg_pr_dbg_pl("  bsg_zynq_pl: watchdog send\n");
             return true;
@@ -135,16 +151,32 @@ class zynq_watchdog : public m_axil_device {
         return false;
     }
 
-    bool pending_read(uintptr_t *address) {
-        return 0;
-    }
+    bool pending_read(uintptr_t *address) { return 0; }
 
     void return_write() {
         bsg_pr_dbg_pl("  bsg_zynq_pl: watchdog return\n");
     }
 
-    void return_read(int32_t data) {
-        /* Unimp */
+    void return_read(int32_t data) { /* Unimp */ }
+
+
+    bool is_read(uintptr_t address) override {
+        return (address >= WATCHDOG_BASE) &&
+               (address < WATCHDOG_BASE + WATCHDOG_SIZE);
+    }
+
+    bool is_write(uintptr_t address) override {
+        return (address >= WATCHDOG_BASE) &&
+               (address < WATCHDOG_BASE + WATCHDOG_SIZE);
+    }
+
+    int32_t read(uintptr_t address) override {
+        bsg_pr_err("  bsg_zynq_pl: watchdog read??\n");
+        return -1;
+    }
+
+    void write(uintptr_t address, int32_t data) override {
+        bsg_pr_dbg_pl("  bsg_zynq_pl: watchdog tick\n");
     }
 };
 

--- a/cosim/include/common/bsg_zynq_pl_hardware.h
+++ b/cosim/include/common/bsg_zynq_pl_hardware.h
@@ -143,14 +143,14 @@ public:
         volatile int32_t *ptr32 = axil_get_ptr32(address);
         int32_t data = *ptr32;
 
-        bsg_pr_debug_pl("  bsg_zynq_pl: AXI reading [%" PRIxPTR "]->%8.8x\n",
+        bsg_pr_dbg_pl("  bsg_zynq_pl: AXI reading [%" PRIxPTR "]->%8.8x\n",
                         address, data);
 
         return data;
     }
 
     inline void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) {
-        bsg_pr_debug_pl("  bsg_zynq_pl: AXI writing [%" PRIxPTR
+        bsg_pr_dbg_pl("  bsg_zynq_pl: AXI writing [%" PRIxPTR
                         "]=%8.8x mask %" PRIu8 "\n",
                         address, data, wstrb);
 

--- a/cosim/include/common/bsg_zynq_pl_hardware.h
+++ b/cosim/include/common/bsg_zynq_pl_hardware.h
@@ -29,203 +29,210 @@
 using namespace std;
 
 class bsg_zynq_pl_hardware {
-    protected:
-        bool debug = ZYNQ_PL_DEBUG;
-        int serial_port;
-        uintptr_t gp0_base_offset = 0;
-        uintptr_t gp1_base_offset = 0;
+public:
+    virtual void start(void) = 0;
+    virtual void stop(void) = 0;
+    virtual void tick(void) = 0;
+    virtual void done(void) = 0;
+    virtual void *allocate_dram(unsigned long len_in_bytes,
+                                unsigned long *physical_ptr) = 0;
+    virtual void free_dram(void *virtual_ptr) = 0;
 
-        inline volatile void *axil_get_ptr(uintptr_t address) {
-            if (address >= gp1_addr_base)
-                return (void *)(address + gp1_base_offset);
-            else
-                return (void *)(address + gp0_base_offset);
-        }
+protected:
+    int serial_port;
+    uintptr_t gp0_base_offset = 0;
+    uintptr_t gp1_base_offset = 0;
 
-        inline volatile int64_t *axil_get_ptr64(uintptr_t address) {
-            return (int64_t *)axil_get_ptr(address);
-        }
+    inline volatile void *axil_get_ptr(uintptr_t address) {
+        if (address >= gp1_addr_base)
+            return (void *)(address + gp1_base_offset);
+        else
+            return (void *)(address + gp0_base_offset);
+    }
 
-        inline volatile int32_t *axil_get_ptr32(uintptr_t address) {
-            return (int32_t *)axil_get_ptr(address);
-        }
+    inline volatile int64_t *axil_get_ptr64(uintptr_t address) {
+        return (int64_t *)axil_get_ptr(address);
+    }
 
-        inline volatile int16_t *axil_get_ptr16(uintptr_t address) {
-            return (int16_t *)axil_get_ptr(address);
-        }
+    inline volatile int32_t *axil_get_ptr32(uintptr_t address) {
+        return (int32_t *)axil_get_ptr(address);
+    }
 
-        inline volatile int8_t *axil_get_ptr8(uintptr_t address) {
-            return (int8_t *)axil_get_ptr(address);
-        }
+    inline volatile int16_t *axil_get_ptr16(uintptr_t address) {
+        return (int16_t *)axil_get_ptr(address);
+    }
 
-    public:
-        void init(void) {
-            // open memory device
-            int fd = open("/dev/mem", O_RDWR | O_SYNC);
-            assert(fd != 0);
+    inline volatile int8_t *axil_get_ptr8(uintptr_t address) {
+        return (int8_t *)axil_get_ptr(address);
+    }
+
+public:
+    void init(void) {
+        // open memory device
+        int fd = open("/dev/mem", O_RDWR | O_SYNC);
+        assert(fd != 0);
 #ifdef GP0_ENABLE
-            // map in first PLAXI region of physical addresses to virtual addresses
-            volatile uintptr_t ptr0 =
-                (uintptr_t)mmap((void *)gp0_addr_base, gp0_addr_size_bytes, PROT_READ | PROT_WRITE,
-                        MAP_SHARED, fd, gp0_addr_base);
-            assert(ptr0 == (uintptr_t)gp0_addr_base);
+        // map in first PLAXI region of physical addresses to virtual addresses
+        volatile uintptr_t ptr0 = (uintptr_t)mmap(
+            (void *)gp0_addr_base, gp0_addr_size_bytes, PROT_READ | PROT_WRITE,
+            MAP_SHARED, fd, gp0_addr_base);
+        assert(ptr0 == (uintptr_t)gp0_addr_base);
 
-            printf("// bsg_zynq_pl: mmap returned %" PRIxPTR " (offset %" PRIxPTR ") errno=%x\n", ptr0,
-                    gp0_base_offset, errno);
+        printf("// bsg_zynq_pl: mmap returned %" PRIxPTR " (offset %" PRIxPTR
+               ") errno=%x\n",
+               ptr0, gp0_base_offset, errno);
 #endif
 
 #ifdef GP1_ENABLE
-            // map in second PLAXI region of physical addresses to virtual addresses
-            volatile uintptr_t ptr1 =
-                (uintptr_t)mmap((void *)gp1_addr_base, gp1_addr_size_bytes, PROT_READ | PROT_WRITE,
-                        MAP_SHARED, fd, gp1_addr_base);
-            assert(ptr1 == (uintptr_t)gp1_addr_base);
+        // map in second PLAXI region of physical addresses to virtual addresses
+        volatile uintptr_t ptr1 = (uintptr_t)mmap(
+            (void *)gp1_addr_base, gp1_addr_size_bytes, PROT_READ | PROT_WRITE,
+            MAP_SHARED, fd, gp1_addr_base);
+        assert(ptr1 == (uintptr_t)gp1_addr_base);
 
-            printf("// bsg_zynq_pl: mmap returned %" PRIxPTR " (offset %" PRIxPTR ") errno=%x\n", ptr1,
-                    gp1_base_offset, errno);
+        printf("// bsg_zynq_pl: mmap returned %" PRIxPTR " (offset %" PRIxPTR
+               ") errno=%x\n",
+               ptr1, gp1_base_offset, errno);
 #endif
-            close(fd);
+        close(fd);
 
 #ifdef UART_ENABLE
-            serial_port = open(UART_DEV_STR, O_RDWR | O_NOCTTY);
+        serial_port = open(UART_DEV_STR, O_RDWR | O_NOCTTY);
 
-            struct termios tty;
-            assert (!tcgetattr(serial_port, &tty));
+        struct termios tty;
+        assert(!tcgetattr(serial_port, &tty));
 
-            tty.c_cflag &= ~PARENB;
-            tty.c_cflag &= ~CSTOPB;
-            tty.c_cflag &= ~CSIZE;
-            tty.c_cflag |=  CS8;
-            tty.c_cflag &= ~CRTSCTS;
-            tty.c_cflag |=  (CREAD | CLOCAL);
+        tty.c_cflag &= ~PARENB;
+        tty.c_cflag &= ~CSTOPB;
+        tty.c_cflag &= ~CSIZE;
+        tty.c_cflag |= CS8;
+        tty.c_cflag &= ~CRTSCTS;
+        tty.c_cflag |= (CREAD | CLOCAL);
 
-            tty.c_lflag &= ~(ICANON | ECHO | ECHOE | ECHONL | ISIG);
+        tty.c_lflag &= ~(ICANON | ECHO | ECHOE | ECHONL | ISIG);
 
-            tty.c_iflag &= ~(IXON | IXOFF | IXANY);
-            tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL);
+        tty.c_iflag &= ~(IXON | IXOFF | IXANY);
+        tty.c_iflag &=
+            ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL);
 
-            tty.c_oflag &= ~OPOST;
-            tty.c_oflag &= ~ONLCR;
+        tty.c_oflag &= ~OPOST;
+        tty.c_oflag &= ~ONLCR;
 
-            tty.c_cc[VTIME] = 0;
-            tty.c_cc[VMIN] = 4;
+        tty.c_cc[VTIME] = 0;
+        tty.c_cc[VMIN] = 4;
 
-            cfsetspeed(&tty, UART_BAUD_ENUM);
+        cfsetspeed(&tty, UART_BAUD_ENUM);
 
-            assert (!tcsetattr(serial_port, TCSANOW, &tty));
+        assert(!tcsetattr(serial_port, TCSANOW, &tty));
 #endif
-        }
+    }
 
-        void deinit(void) {
+    void deinit(void) {
 #ifdef UART_ENABLE
-            close(serial_port);
+        close(serial_port);
 #endif
-        }
+    }
 
 #ifdef AXI_ENABLE
-        inline int32_t axil_read(uintptr_t address) {
-            // Only aligned 32B reads are currently supported
-            assert (alignof(address) >= 4);
+    inline int32_t axil_read(uintptr_t address) {
+        // Only aligned 32B reads are currently supported
+        assert(alignof(address) >= 4);
 
-            // We use unsigned here because the data is sign extended from the AXI bus
+        // We use unsigned here because the data is sign extended from the AXI
+        // bus
+        volatile int32_t *ptr32 = axil_get_ptr32(address);
+        int32_t data = *ptr32;
+
+        bsg_pr_debug_pl("  bsg_zynq_pl: AXI reading [%" PRIxPTR "]->%8.8x\n",
+                        address, data);
+
+        return data;
+    }
+
+    inline void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) {
+        bsg_pr_debug_pl("  bsg_zynq_pl: AXI writing [%" PRIxPTR
+                        "]=%8.8x mask %" PRIu8 "\n",
+                        address, data, wstrb);
+
+        // for now we don't support alternate write strobes
+        assert(wstrb == 0XF || wstrb == 0x3 || wstrb == 0x1);
+
+        if (wstrb == 0xF) {
             volatile int32_t *ptr32 = axil_get_ptr32(address);
-            int32_t data = *ptr32;
-
-            if (debug)
-                printf("  bsg_zynq_pl: AXI reading [%" PRIxPTR "]->%8.8x\n", address, data);
-
-            return data;
+            *ptr32 = data;
+        } else if (wstrb == 0x3) {
+            volatile int16_t *ptr16 = axil_get_ptr16(address);
+            *ptr16 = data;
+        } else if (wstrb == 0x1) {
+            volatile int8_t *ptr8 = axil_get_ptr8(address);
+            *ptr8 = data;
+        } else {
+            assert(false);  // Illegal write strobe
         }
-
-        inline void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) {
-            if (debug)
-                printf("  bsg_zynq_pl: AXI writing [%" PRIxPTR "]=%8.8x mask %" PRIu8 "\n", address, data,
-                        wstrb);
-
-            // for now we don't support alternate write strobes
-            assert(wstrb == 0XF || wstrb == 0x3 || wstrb == 0x1);
-
-            if (wstrb == 0xF) {
-                volatile int32_t *ptr32 = axil_get_ptr32(address);
-                *ptr32 = data;
-            } else if (wstrb == 0x3) {
-                volatile int16_t *ptr16 = axil_get_ptr16(address);
-                *ptr16 = data;
-            } else if (wstrb == 0x1) {
-                volatile int8_t *ptr8 = axil_get_ptr8(address);
-                *ptr8 = data;
-            } else {
-                assert(false); // Illegal write strobe
-            }
-        }
+    }
 #endif
 
 #ifdef UART_ENABLE
-        // Must sync to verilog
-        //     typedef struct packed
-        //     {
-        //       logic [31:0] data;
-        //       logic [6:0]  addr8to2;
-        //       logic        wr_not_rd;
-        //     } bsg_uart_pkt_s;
+    // Must sync to verilog
+    //     typedef struct packed
+    //     {
+    //       logic [31:0] data;
+    //       logic [6:0]  addr8to2;
+    //       logic        wr_not_rd;
+    //     } bsg_uart_pkt_s;
 
-        void uart_write(uintptr_t addr, int32_t data, uint8_t wmask) {
-            int count;
-            uint64_t uart_pkt = 0;
-            uintptr_t word = addr >> 2;
+    void uart_write(uintptr_t addr, int32_t data, uint8_t wmask) {
+        int count;
+        uint64_t uart_pkt = 0;
+        uintptr_t word = addr >> 2;
 
-            uart_pkt |= (data & 0xffffffff) << 8;
-            uart_pkt |= (word & 0x0000007f) << 1;
-            uart_pkt |= (1    & 0x00000001) << 0;
+        uart_pkt |= (data & 0xffffffff) << 8;
+        uart_pkt |= (word & 0x0000007f) << 1;
+        uart_pkt |= (1 & 0x00000001) << 0;
 
-            count = write(serial_port, &uart_pkt, 5);
-            bsg_pr_dbg_ps("uart tx write: %x bytes\n", count);
-        }
+        count = write(serial_port, &uart_pkt, 5);
+        bsg_pr_dbg_ps("uart tx write: %x bytes\n", count);
+    }
 
-        int32_t uart_read(uintptr_t addr) {
-            int count;
-            uint64_t uart_pkt = 0;
-            uintptr_t word = addr >> 2;
+    int32_t uart_read(uintptr_t addr) {
+        int count;
+        uint64_t uart_pkt = 0;
+        uintptr_t word = addr >> 2;
 
-            uart_pkt |= (0    & 0xffffffff) << 8;
-            uart_pkt |= (word & 0x0000007f) << 1;
-            uart_pkt |= (0    & 0x00000001) << 0;
+        uart_pkt |= (0 & 0xffffffff) << 8;
+        uart_pkt |= (word & 0x0000007f) << 1;
+        uart_pkt |= (0 & 0x00000001) << 0;
 
-            count = write(serial_port, &uart_pkt, 5);
-            bsg_pr_dbg_ps("uart rx write: %x bytes\n", count);
+        count = write(serial_port, &uart_pkt, 5);
+        bsg_pr_dbg_ps("uart rx write: %x bytes\n", count);
 
-            int32_t read_buf;
-            count = read(serial_port, &read_buf, 4);
-            bsg_pr_dbg_ps("uart rx read: %x\n", read_buf, count);
+        int32_t read_buf;
+        count = read(serial_port, &read_buf, 4);
+        bsg_pr_dbg_ps("uart rx read: %x\n", read_buf, count);
 
-            return read_buf;
-        }
+        return read_buf;
+    }
 #endif
 
-    public:
-        virtual int32_t shell_read(uintptr_t addr) = 0;
-        virtual void shell_write(uintptr_t addr, int32_t data, uint8_t wmask) = 0;
+public:
+    virtual int32_t shell_read(uintptr_t addr) = 0;
+    virtual void shell_write(uintptr_t addr, int32_t data, uint8_t wmask) = 0;
 
-        virtual void shell_read4(uintptr_t addr, int32_t *data0, int32_t *data1, int32_t *data2, int32_t *data3) {
-            *data0 = shell_read(addr+0);
-            *data1 = shell_read(addr+4);
-            *data2 = shell_read(addr+8);
-            *data3 = shell_read(addr+12);
-        }
+    virtual void shell_read4(uintptr_t addr, int32_t *data0, int32_t *data1,
+                             int32_t *data2, int32_t *data3) {
+        *data0 = shell_read(addr + 0);
+        *data1 = shell_read(addr + 4);
+        *data2 = shell_read(addr + 8);
+        *data3 = shell_read(addr + 12);
+    }
 
-        virtual void shell_write4(uintptr_t addr, int32_t data0, int32_t data1, int32_t data2, int32_t data3) {
-            shell_write(addr+0, data0, 0xf);
-            shell_write(addr+4, data1, 0xf);
-            shell_write(addr+8, data2, 0xf);
-            shell_write(addr+12, data3, 0xf);
-        }
-
-    public:
-        virtual void poll(void) { };
-        virtual void tick(void) = 0;
-        virtual void done(void) = 0;
-        virtual void *allocate_dram(unsigned long len_in_bytes, unsigned long *physical_ptr) = 0;
-        virtual void free_dram(void *virtual_ptr) = 0;
+    virtual void shell_write4(uintptr_t addr, int32_t data0, int32_t data1,
+                              int32_t data2, int32_t data3) {
+        shell_write(addr + 0, data0, 0xf);
+        shell_write(addr + 4, data1, 0xf);
+        shell_write(addr + 8, data2, 0xf);
+        shell_write(addr + 12, data3, 0xf);
+    }
 };
 
 #endif

--- a/cosim/include/common/bsg_zynq_pl_simulation.h
+++ b/cosim/include/common/bsg_zynq_pl_simulation.h
@@ -32,323 +32,372 @@ using namespace boost::coroutines2;
 using namespace std::placeholders;
 
 class bsg_zynq_pl_simulation {
-    protected:
+public:
+    virtual void start(void) { create_peripherals(); }
+    virtual void stop(void) { destroy_peripherals(); }
+    virtual void tick(void) = 0;
+    virtual void done(void) = 0;
+    virtual void *allocate_dram(unsigned long len_in_bytes,
+                                unsigned long *physical_ptr) = 0;
+    virtual void free_dram(void *virtual_ptr) = 0;
 
-        std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> > axi_gp0;
-        std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> > axi_gp1;
-        std::unique_ptr<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> > axi_gp2;
-        std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> > axi_hp0;
-        std::unique_ptr<axils<HP1_ADDR_WIDTH, HP1_DATA_WIDTH> > axi_hp1;
-        std::unique_ptr<axils<HP2_ADDR_WIDTH, HP2_DATA_WIDTH> > axi_hp2;
+protected:
+    std::unique_ptr<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH>> axi_gp0;
+    std::unique_ptr<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH>> axi_gp1;
+    std::unique_ptr<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH>> axi_gp2;
+    std::unique_ptr<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH>> axi_hp0;
+    std::unique_ptr<axils<HP1_ADDR_WIDTH, HP1_DATA_WIDTH>> axi_hp1;
+    std::unique_ptr<axils<HP2_ADDR_WIDTH, HP2_DATA_WIDTH>> axi_hp2;
 
-        std::unique_ptr<zynq_uart> uart;
-        std::unique_ptr<zynq_scratchpad> scratchpad;
-        std::unique_ptr<zynq_watchdog> watchdog;
+    std::unique_ptr<zynq_uart> uart;
+    std::unique_ptr<zynq_scratchpad> scratchpad;
+    std::unique_ptr<zynq_watchdog> watchdog;
 
-        coroutine<void>::pull_type *co_next;
-        coroutine<void>::pull_type *co_polls;
-        coroutine<void>::pull_type *co_pollm;
+    std::vector<std::unique_ptr<coro_t>> co_list;
 
-        std::function<void ()> f_tick = std::bind(&bsg_zynq_pl_simulation::tick, this);
-        std::function<void ()> f_next_tick = std::bind(&bsg_zynq_pl_simulation::next_tick, this);
-        std::function<void ()> f_poll_tick = std::bind(&bsg_zynq_pl_simulation::poll_tick, this);
-
-        void next(coroutine<void>::push_type &yield) {
-            while (1) {
-                tick();
-                yield();
-            }
-        }
-
-        void init() {
-#ifdef SIM_BACKPRESSURE_ENABLE
-            srand(SIM_BACKPRESSURE_SEED);
-#endif
-#ifdef SCRATCHPAD_ENABLE
-            scratchpad = std::make_unique<zynq_scratchpad>();
-#endif
-#ifdef WATCHDOG_ENABLE
-            watchdog = std::make_unique<zynq_watchdog>();
-#endif
-#ifdef UART_ENABLE
-            uart = std::make_unique<zynq_uart>();
-#endif
+    void init() {
 #ifdef GP0_ENABLE
-            axi_gp0 = std::make_unique<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH> >(
-                    STRINGIFY(GP0_HIER_BASE));
-            axi_gp0->reset(f_tick);
+        axi_gp0 = std::make_unique<axilm<GP0_ADDR_WIDTH, GP0_DATA_WIDTH>>(
+            STRINGIFY(GP0_HIER_BASE));
+        co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+            axi_gp0->reset(yield);
+        }));
 #endif
 #ifdef GP1_ENABLE
-            axi_gp1 = std::make_unique<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH> >(
-                    STRINGIFY(GP1_HIER_BASE));
-            axi_gp1->reset(f_tick);
+        axi_gp1 = std::make_unique<axilm<GP1_ADDR_WIDTH, GP1_DATA_WIDTH>>(
+            STRINGIFY(GP1_HIER_BASE));
+        co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+            axi_gp1->reset(yield);
+        }));
 #endif
 #ifdef GP2_ENABLE
-            axi_gp2 = std::make_unique<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH> >(
-                    STRINGIFY(GP2_HIER_BASE));
-            axi_gp2->reset(f_tick);
+        axi_gp2 = std::make_unique<axilm<GP2_ADDR_WIDTH, GP2_DATA_WIDTH>>(
+            STRINGIFY(GP2_HIER_BASE));
+        co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+            axi_gp2->reset(yield);
+        }));
 #endif
 #ifdef HP0_ENABLE
 #ifndef AXI_MEM_ENABLE
-            axi_hp0 = std::make_unique<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH> >(
-                    STRINGIFY(HP0_HIER_BASE));
-            axi_hp0->reset(f_tick);
+        axi_hp0 = std::make_unique<axils<HP0_ADDR_WIDTH, HP0_DATA_WIDTH>>(
+            STRINGIFY(HP0_HIER_BASE));
+        co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+            axi_hp0->reset(yield);
+        }));
 #endif
 #endif
 #ifdef HP1_ENABLE
-            axi_hp1 = std::make_unique<axils<HP1_ADDR_WIDTH, HP1_DATA_WIDTH> >(
-                    STRINGIFY(HP1_HIER_BASE));
-            axi_hp1->reset(f_tick);
+        axi_hp1 = std::make_unique<axils<HP1_ADDR_WIDTH, HP1_DATA_WIDTH>>(
+            STRINGIFY(HP1_HIER_BASE));
+        co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+            axi_hp1->reset(yield);
+        }));
 #endif
 #ifdef HP2_ENABLE
-            axi_hp2 = std::make_unique<axils<HP2_ADDR_WIDTH, HP2_DATA_WIDTH> >(
-                    STRINGIFY(HP2_HIER_BASE));
-            axi_hp2->reset(f_tick);
+        axi_hp2 = std::make_unique<axils<HP2_ADDR_WIDTH, HP2_DATA_WIDTH>>(
+            STRINGIFY(HP2_HIER_BASE));
+        co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+            axi_hp2->reset(yield);
+        }));
 #endif
-            co_next  = new coroutine<void>::pull_type{std::bind(&bsg_zynq_pl_simulation::next, this, _1)};
-            co_polls = new coroutine<void>::pull_type{std::bind(&bsg_zynq_pl_simulation::axils_poll, this, _1)};
-            co_pollm = new coroutine<void>::pull_type{std::bind(&bsg_zynq_pl_simulation::axilm_poll, this, _1)};
-
-            // Start the main tick thread
-            (*co_next)();
+        // Do the reset
+        while (co_list.size() > 0) {
+            next();
         }
-
-        void axils_poll(coroutine<void>::push_type &yield) {
-#ifdef HP1_ENABLE
-            while (1) {
-#ifdef SIM_BACKPRESSURE_ENABLE
-                if ((rand() % 100) < SIM_BACKPRESSURE_CHANCE) {
-                    for (int i = 0; i < SIM_BACKPRESSURE_LENGTH; i++) {
-                        yield();
-                    }
-                }
-#endif
-                int araddr = axi_hp1->p_araddr;
-                if (!axi_hp1->p_arvalid) {
-                    yield();
+    }
+    
+    void create_peripherals() {
 #ifdef SCRATCHPAD_ENABLE
-                } else if (scratchpad->is_read(araddr)) {
-                    axi_hp1->axil_read_helper((s_axil_device *)scratchpad.get(), f_next_tick);
+        scratchpad = std::make_unique<zynq_scratchpad>();
 #endif
-#ifdef UART_ENABLE
-                } else if (uart->is_read(araddr)) {
-                    axi_hp1->axil_read_helper((s_axil_device *)uart.get(), f_next_tick);
-#endif
-                } else {
-                    bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device read at [%x]\n", araddr);
-                }
-
-                int awaddr = axi_hp1->p_awaddr;
-                bool test = axi_hp1->p_awvalid;
-                if (!axi_hp1->p_awvalid) {
-                    yield();
-#ifdef SCRATCHPAD_ENABLE
-                } else if (scratchpad->is_write(awaddr)) {
-                    axi_hp1->axil_write_helper((s_axil_device *)scratchpad.get(), f_next_tick);
-#endif
-#ifdef UART_ENABLE
-                } else if (uart->is_write(awaddr)) {
-                    axi_hp1->axil_write_helper((s_axil_device *)uart.get(), f_next_tick);
-#endif
-                } else {
-                    bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device write at [%x]\n", awaddr);
-                }
-            }
-#endif
-        }
-
-        void axilm_poll(coroutine<void>::push_type &yield) {
-            uintptr_t address;
-            int32_t data, ret;
-            uint8_t wmask;
-
-#ifdef GP2_ENABLE
-            while (1) {
-                if (0) {
 #ifdef WATCHDOG_ENABLE
-                } else if (watchdog->pending_write(&address, &data, &wmask)) {
-                    axi_gp2->axil_write_helper(address, data, wmask, f_next_tick);
-                    watchdog->return_write();
-                } else if (watchdog->pending_read(&address)) {
-                    ret = axi_gp2->axil_read_helper(address, f_next_tick);
-                    watchdog->return_read(ret);
+        watchdog = std::make_unique<zynq_watchdog>();
 #endif
-                } else {
-                    yield();
-                }
-            }
+#ifdef UART_ENABLE
+        uart = std::make_unique<zynq_uart>();
 #endif
+    }
+
+    void destroy_peripherals() {
+        scratchpad.reset();
+        watchdog.reset();
+        uart.reset();
+    }
+
+    void next() {
+        std::erase_if(co_list, [](auto &ptr) {
+            (*ptr)();
+            return !(*ptr);
+        });
+        pollm_helper();
+        polls_helper();
+        tick();
+    }
+
+    void polls_helper() {
+        uintptr_t addr;
+        int32_t data;
+        uint8_t wstrb;
+#ifdef HP1_ENABLE
+        if (!axi_hp1->axil_has_read(&addr)) {
+        } else if (scratchpad.get() && scratchpad->is_read(addr)) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                axi_hp1->axil_read_helper((s_axil_device *)scratchpad.get(),
+                                          yield);
+            }));
+        } else if (uart.get() && uart->is_read(addr)) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                axi_hp1->axil_read_helper((s_axil_device *)uart.get(), yield);
+            }));
+        } else if (watchdog.get() && watchdog->is_read(addr)) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                axi_hp1->axil_read_helper((s_axil_device *)watchdog.get(), yield);
+            }));
+        } else {
+            bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device read at [%x]\n",
+                       addr);
         }
+
+        if (!axi_hp1->axil_has_write(&addr)) {
+        } else if (scratchpad && scratchpad->is_write(addr)) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                axi_hp1->axil_write_helper((s_axil_device *)scratchpad.get(),
+                                           yield);
+            }));
+        } else if (uart.get() && uart->is_write(addr)) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                axi_hp1->axil_write_helper((s_axil_device *)uart.get(), yield);
+            }));
+        } else if (watchdog.get() && watchdog->is_write(addr)) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                axi_hp1->axil_write_helper((s_axil_device *)watchdog.get(), yield);
+            }));
+        } else {
+            bsg_pr_err("  bsg_zynq_pl: Unsupported AXI device write at [%x]\n",
+                       addr);
+        }
+#endif
+    }
+
+    void pollm_helper() {
+        uintptr_t addr;
+        int32_t data;
+        uint8_t wstrb;
+#if GP2_ENABLE
+        if (watchdog.get() && watchdog->pending_write(&addr, &data, &wstrb)) {
+            axil_write(2, addr, data, wstrb,
+                       [=]() { watchdog->return_write(); });
+        } else if (watchdog.get() && watchdog->pending_read(&addr)) {
+            axil_read(2, addr,
+                      [=](int32_t rdata) { watchdog->return_read(rdata); });
+        }
+#endif
+    }
 
 #ifdef AXI_ENABLE
-        int32_t axil_read(uintptr_t address) {
-            uintptr_t address_orig = address;
-            int index = -1;
-            int data;
-
-            // we subtract the bases to make it consistent with the Zynq AXI IPI
-            // implementation
-
-            if (address >= GP0_ADDR_BASE &&
-                    address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
-                index = 0;
-                address = address - GP0_ADDR_BASE;
-            } else if (address >= GP1_ADDR_BASE &&
-                    address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
-                index = 1;
-                address = address - GP1_ADDR_BASE;
-            } else {
-                bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
-                return -1;
-            }
-
-            if (index == 0) {
-                data = axi_gp0->axil_read_helper(address, f_tick);
-            } else if (index == 1) {
-                data = axi_gp1->axil_read_helper(address, f_tick);
-            }
-
-            bsg_pr_dbg_pl("  bsg_zynq_pl: AXI reading [%x] -> port %d, [%x]->%8.8x\n",
-                    address_orig, index, address, data);
-
-            return data;
+    void axil_read(int port, uintptr_t addr,
+                   std::function<void(int32_t)> callback) {
+        if (port == 2) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                int32_t rdata = axi_gp2->axil_read_helper(addr, yield);
+                callback(rdata);
+            }));
+        } else if (port == 1) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                int32_t rdata = axi_gp1->axil_read_helper(addr, yield);
+                callback(rdata);
+            }));
+        } else {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                int32_t rdata = axi_gp0->axil_read_helper(addr, yield);
+                callback(rdata);
+            }));
         }
+    }
 
-        void axil_write(uintptr_t address, int32_t data, uint8_t wstrb) {
-            uintptr_t address_orig = address;
-            int index = -1;
-
-            // we subtract the bases to make it consistent with the Zynq AXI IPI
-            // implementation
-
-            if (address >= GP0_ADDR_BASE &&
-                    address <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
-                index = 0;
-                address = address - GP0_ADDR_BASE;
-            } else if (address >= GP1_ADDR_BASE &&
-                    address <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
-                index = 1;
-                address = address - GP1_ADDR_BASE;
-            } else {
-                bsg_pr_err("  bsg_zynq_pl: unsupported AXIL port %d\n", index);
-                return;
-            }
-
-            bsg_pr_dbg_pl("  bsg_zynq_pl: AXI writing [%x] -> port %d, [%x]<-%8.8x\n",
-                    address_orig, index, address, data);
-
-            if (index == 0) {
-                axi_gp0->axil_write_helper(address, data, wstrb, f_tick);
-            } else if (index == 1) {
-                axi_gp1->axil_write_helper(address, data, wstrb, f_tick);
-            }
+    void axil_write(int port, uintptr_t addr, int32_t data, uint8_t wstrb,
+                    std::function<void()> callback) {
+        if (port == 2) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                axi_gp2->axil_write_helper(addr, data, wstrb, yield);
+                callback();
+            }));
+        } else if (port == 1) {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                axi_gp1->axil_write_helper(addr, data, wstrb, yield);
+                callback();
+            }));
+        } else {
+            co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+                axi_gp0->axil_write_helper(addr, data, wstrb, yield);
+                callback();
+            }));
         }
+    }
 #endif
 #ifdef UART_ENABLE
-        // Must sync to verilog
-        //     typedef struct packed
-        //     {
-        //       logic [31:0] data;
-        //       logic [6:0]  addr8to2;
-        //       logic        wr_not_rd;
-        //     } bsg_uart_pkt_s;
-        void uart_write(uintptr_t addr, int32_t data, uint8_t wmask) {
-            uint64_t uart_pkt = 0;
-            uintptr_t word = addr >> 2;
+    // Must sync to verilog
+    //     typedef struct packed
+    //     {
+    //       logic [31:0] data;
+    //       logic [5:0]  addr7to2;
+    //       logic        wr_not_rd;
+    //       logic        port;
+    //     } bsg_uart_pkt_s;
+    void uart_write(int port, uintptr_t addr, int32_t data, uint8_t wstrb,
+                    std::function<void()> callback) {
+        uint64_t uart_pkt = 0;
+        uintptr_t word = addr >> 2;
+        int rdwr = 1;
 
-            uart_pkt |= (data & 0xffffffff) << 8;
-            uart_pkt |= (word & 0x0000007f) << 1;
-            uart_pkt |= (1    & 0x00000001) << 0;
+        uart_pkt |= (data & 0xffffffff) << 8;
+        uart_pkt |= (word & 0x0000003f) << 2;
+        uart_pkt |= (rdwr & 0x00000001) << 1;
+        uart_pkt |= (port & 0x00000001) << 0;
 
-            for (int i = 0; i < 40; i+=8) {
+        co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+            for (int i = 0; i < 40; i += 8) {
                 uint8_t b = (uart_pkt >> i) & 0xff;
-                uart->tx_helper(b, f_poll_tick);
+                do {
+                    yield();
+                } while (!uart->tx_helper(b));
             }
-        }
+            callback();
+        }));
+    }
 
-        int32_t uart_read(uintptr_t addr) {
-            uint64_t uart_pkt = 0;
-            uintptr_t word = addr >> 2;
+    void uart_read(int port, uintptr_t addr,
+                   std::function<void(int32_t)> callback) {
+        uint64_t uart_pkt = 0;
+        uintptr_t word = addr >> 2;
+        int32_t data = 0;
+        int rdwr = 0;
+
+        uart_pkt |= (data & 0xffffffff) << 8;
+        uart_pkt |= (word & 0x0000003f) << 2;
+        uart_pkt |= (rdwr & 0x00000001) << 1;
+        uart_pkt |= (port & 0x00000001) << 0;
+
+        co_list.push_back(std::make_unique<coro_t>([=](yield_t &yield) {
+            for (int i = 0; i < 40; i += 8) {
+                uint8_t b = (uart_pkt >> i) & 0xff;
+                do {
+                    yield();
+                } while (!uart->tx_helper(b));
+            }
+
             int32_t data = 0;
-
-            uart_pkt |= (data & 0xffffffff) << 8;
-            uart_pkt |= (word & 0x0000007f) << 1;
-            uart_pkt |= (0    & 0x00000001) << 0;
-
-            for (int i = 0; i < 40; i+=8) {
-                uint8_t b = (uart_pkt >> i) & 0xff;
-                uart->tx_helper(b, f_poll_tick);
-            }
-
             uint8_t d;
-            for (int i = 0; i < 32; i+=8) {
-                d = uart->rx_helper(f_poll_tick);
+            for (int i = 0; i < 32; i += 8) {
+                do {
+                    yield();
+                } while (!uart->rx_helper(&d));
                 data |= (d << i);
             }
+            callback(data);
+        }));
+    }
+#endif
+public:
+    virtual void shell_write(uintptr_t addr, int32_t data, uint8_t wstrb) {
+        int port;
 
-            return data;
-        }
+        // we subtract the bases to make it consistent with the Zynq AXI IPI
+        // implementation
+        if (0) {
+#ifdef GP0_ENABLE
+        } else if (addr >= GP0_ADDR_BASE &&
+            addr <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
+            port = 0;
+            addr = addr - GP0_ADDR_BASE;
 #endif
-        void next_tick() {
-            (*co_next)();
-        }
-
-        void poll_tick() {
-#ifdef HP0_ENABLE
-#ifndef AXI_MEM_ENABLE
-            (*co_polls)();
+#ifdef GP1_ENABLE
+        } else if (addr >= GP1_ADDR_BASE &&
+                   addr <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
+            port = 1;
+            addr = addr - GP1_ADDR_BASE;
 #endif
-#endif
-#ifdef HP1_ENABLE
-            (*co_polls)();
-#endif
-#ifdef HP2_ENABLE
-            (*co_polls)();
-#endif
-            // GP0 and GP1 are always Zynq-Driven
-#ifdef GP2_ENABLE
-            (*co_pollm)();
-#endif
-            (*co_next)();
+        } else {
+            bsg_pr_err("  bsg_zynq_pl: unsupported AXIL address: %x\n", addr);
+            return;
         }
 
-    public:
-        virtual void shell_write(uintptr_t addr, int32_t data, uint8_t wmask) {
+        bool done = false;
+        auto f_call = [&]() { done = true; };
 #ifdef HOST_ZYNQ
-            axil_write(addr, data, wmask);
+        axil_write(port, addr, data, wstrb, f_call);
 #else
-            uart_write(addr, data, wmask);
+        uart_write(port, addr, data, wstrb, f_call);
 #endif
+        do {
+            next();
+        } while (!done);
+
+        bsg_pr_dbg_pl("  bsg_zynq_pl: AXI writing port %d, [%x]<-%8.8x\n", port,
+                      addr, data);
+
+        return;
+    }
+
+    virtual int32_t shell_read(uintptr_t addr) {
+        int port;
+
+        // we subtract the bases to make it consistent with the Zynq AXI IPI
+        // implementation
+        if (0) {
+#ifdef GP0_ENABLE
+        } else if (addr >= GP0_ADDR_BASE &&
+            addr <= GP0_ADDR_BASE + GP0_ADDR_SIZE_BYTES) {
+            port = 0;
+            addr = addr - GP0_ADDR_BASE;
+#endif
+#ifdef GP1_ENABLE
+        } else if (addr >= GP1_ADDR_BASE &&
+                   addr <= GP1_ADDR_BASE + GP1_ADDR_SIZE_BYTES) {
+            port = 1;
+            addr = addr - GP1_ADDR_BASE;
+#endif
+        } else {
+            bsg_pr_err("  bsg_zynq_pl: unsupported AXIL address: %x\n", addr);
+            return -1;
         }
 
-        virtual int32_t shell_read(uintptr_t addr) {
+        bool done = false;
+        int32_t rdata;
+        auto f_call = [&](int32_t x) {
+            rdata = x;
+            done = true;
+        };
 #ifdef HOST_ZYNQ
-            return axil_read(addr);
+        axil_read(port, addr, f_call);
 #else
-            return uart_read(addr);
+        uart_read(port, addr, f_call);
 #endif
-        }
+        do {
+            next();
+        } while (!done);
 
-        virtual void shell_read4(uintptr_t addr, int32_t *data0, int32_t *data1, int32_t *data2, int32_t *data3) {
-            *data0 = shell_read(addr+0);
-            *data1 = shell_read(addr+4);
-            *data2 = shell_read(addr+8);
-            *data3 = shell_read(addr+12);
-        }
+        bsg_pr_dbg_pl("  bsg_zynq_pl: AXI reading port %d [%x] -> %8.8x\n",
+                      port, addr, rdata);
 
-        virtual void shell_write4(uintptr_t addr, int32_t data0, int32_t data1, int32_t data2, int32_t    data3) {
-            shell_write(addr+0, data0, 0xf);
-            shell_write(addr+4, data1, 0xf);
-            shell_write(addr+8, data2, 0xf);
-            shell_write(addr+12, data3, 0xf);
-        }
+        return rdata;
+    }
 
-    public:
-        virtual void poll(void) { poll_tick(); };
-        virtual void tick(void) = 0;
-        virtual void done(void) = 0;
-        virtual void *allocate_dram(unsigned long len_in_bytes, unsigned long *physical_ptr) = 0;
-        virtual void free_dram(void *virtual_ptr) = 0;
+    virtual void shell_read4(uintptr_t addr, int32_t *data0, int32_t *data1,
+                             int32_t *data2, int32_t *data3) {
+        *data0 = shell_read(addr + 0);
+        *data1 = shell_read(addr + 4);
+        *data2 = shell_read(addr + 8);
+        *data3 = shell_read(addr + 12);
+    }
+
+    virtual void shell_write4(uintptr_t addr, int32_t data0, int32_t data1,
+                              int32_t data2, int32_t data3) {
+        shell_write(addr + 0, data0, 0xf);
+        shell_write(addr + 4, data1, 0xf);
+        shell_write(addr + 8, data2, 0xf);
+        shell_write(addr + 12, data3, 0xf);
+    }
 };
 
 #endif

--- a/cosim/include/common/bsg_zynq_pl_simulation.h
+++ b/cosim/include/common/bsg_zynq_pl_simulation.h
@@ -31,6 +31,18 @@ using namespace bsg_nonsynth_dpi;
 using namespace boost::coroutines2;
 using namespace std::placeholders;
 
+
+// Copy this to C++14 so we don't have to upgrade
+// https://stackoverflow.com/questions/3424962/where-is-erase-if
+// for std::vector
+namespace std {
+    template <class T, class A, class Predicate>
+    void erase_if(vector<T, A>& c, Predicate pred) {
+        c.erase(remove_if(c.begin(), c.end(), pred), c.end());
+    }
+}
+
+
 class bsg_zynq_pl_simulation {
 public:
     virtual void start(void) { create_peripherals(); }
@@ -129,6 +141,7 @@ protected:
             (*ptr)();
             return !(*ptr);
         });
+
         pollm_helper();
         polls_helper();
         tick();

--- a/cosim/include/common/zynq_headers.h
+++ b/cosim/include/common/zynq_headers.h
@@ -40,10 +40,10 @@ typedef uint32_t uint32x4_t[4];
 #define GP0_HIER_BASE ""
 #endif
 
+#ifndef GP0_ADDR_SIZE_BYTES
 #ifndef GP0_ADDR_WIDTH
 #error GP0_ADDR_WIDTH must be defined
 #endif
-#ifndef GP0_ADDR_SIZE_BYTES
 #define GP0_ADDR_SIZE_BYTES (1ULL << GP0_ADDR_WIDTH)
 #endif
 static uintptr_t gp0_addr_size_bytes = (uintptr_t) GP0_ADDR_SIZE_BYTES;
@@ -70,10 +70,10 @@ static uintptr_t gp0_addr_base = (uintptr_t) GP0_ADDR_BASE;
 #define GP1_HIER_BASE ""
 #endif
 
+#ifndef GP1_ADDR_SIZE_BYTES
 #ifndef GP1_ADDR_WIDTH
 #error GP1_ADDR_WIDTH must be defined
 #endif
-#ifndef GP1_ADDR_SIZE_BYTES
 #define GP1_ADDR_SIZE_BYTES (1ULL << GP1_ADDR_WIDTH)
 #endif
 static uintptr_t gp1_addr_size_bytes = (uintptr_t) GP1_ADDR_SIZE_BYTES;
@@ -108,10 +108,10 @@ static uintptr_t gp1_addr_base = (uintptr_t) GP1_ADDR_BASE;
 #define GP2_HIER_BASE ""
 #endif
 
+#ifndef GP2_ADDR_SIZE_BYTES
 #ifndef GP2_ADDR_WIDTH
 #error GP2_ADDR_WIDTH must be defined
 #endif
-#ifndef GP2_ADDR_SIZE_BYTES
 #define GP2_ADDR_SIZE_BYTES (1ULL << GP2_ADDR_WIDTH)
 #endif
 static uintptr_t gp2_addr_size_bytes = (uintptr_t) GP2_ADDR_SIZE_BYTES;
@@ -138,10 +138,10 @@ static uintptr_t gp2_addr_base = (uintptr_t) GP2_ADDR_BASE;
 #define HP0_HIER_BASE ""
 #endif
 
+#ifndef HP0_ADDR_SIZE_BYTES
 #ifndef HP0_ADDR_WIDTH
 #error HP0_ADDR_WIDTH must be defined
 #endif
-#ifndef HP0_ADDR_SIZE_BYTES
 #define HP0_ADDR_SIZE_BYTES (1ULL << HP0_ADDR_WIDTH)
 #endif
 static uintptr_t hp0_addr_size_bytes = (uintptr_t) HP0_ADDR_SIZE_BYTES;
@@ -170,10 +170,10 @@ static uintptr_t hp0_addr_base = (uintptr_t) HP0_ADDR_BASE;
 #define HP1_HIER_BASE ""
 #endif
 
+#ifndef HP1_ADDR_SIZE_BYTES
 #ifndef HP1_ADDR_WIDTH
 #error HP1_ADDR_WIDTH must be defined
 #endif
-#ifndef HP1_ADDR_SIZE_BYTES
 #define HP1_ADDR_SIZE_BYTES (1ULL << HP1_ADDR_WIDTH)
 #endif
 static uintptr_t hp1_addr_size_bytes = (uintptr_t) HP1_ADDR_SIZE_BYTES;
@@ -200,10 +200,10 @@ static uintptr_t hp1_addr_base = (uintptr_t) HP1_ADDR_BASE;
 #define HP2_HIER_BASE ""
 #endif
 
+#ifndef HP2_ADDR_SIZE_BYTES
 #ifndef HP2_ADDR_WIDTH
 #error HP2_ADDR_WIDTH must be defined
 #endif
-#ifndef HP2_ADDR_SIZE_BYTES
 #define HP2_ADDR_SIZE_BYTES (1ULL << HP2_ADDR_WIDTH)
 #endif
 static uintptr_t hp2_addr_size_bytes = (uintptr_t) HP2_ADDR_SIZE_BYTES;

--- a/cosim/include/vcs/bsg_zynq_pl.h
+++ b/cosim/include/vcs/bsg_zynq_pl.h
@@ -20,6 +20,7 @@
 #include "bsg_zynq_pl_simulation.h"
 
 extern "C" { void bsg_dpi_next(); }
+extern "C" { int bsg_dpi_time(); }
 
 class bsg_zynq_pl : public bsg_zynq_pl_simulation {
     public:

--- a/cosim/include/vcs/bsg_zynq_pl.h
+++ b/cosim/include/vcs/bsg_zynq_pl.h
@@ -41,7 +41,10 @@ class bsg_zynq_pl : public bsg_zynq_pl_simulation {
 
         void *allocate_dram(unsigned long len_in_bytes, unsigned long *physical_ptr) override {
             bsg_pr_info("  bsg_zynq_pl: Allocated dummy DRAM\n");
-            return (void *)(physical_ptr = (unsigned long *)0xdeadbeef);
+            void *virtual_ptr = (unsigned long *)malloc(len_in_bytes);
+            *physical_ptr = (unsigned long)virtual_ptr;
+
+            return virtual_ptr;
         }
 
         void free_dram(void *virtual_ptr) override {

--- a/cosim/include/verilator/bsg_zynq_pl.h
+++ b/cosim/include/verilator/bsg_zynq_pl.h
@@ -23,6 +23,8 @@
 #include "Vbsg_nonsynth_zynq_testbench.h"
 #include "verilated.h"
 
+extern "C" { int bsg_dpi_time(); }
+
 class bsg_zynq_pl : public bsg_zynq_pl_simulation {
     Vbsg_nonsynth_zynq_testbench *tb;
     VerilatedFstC *wf;
@@ -68,7 +70,10 @@ class bsg_zynq_pl : public bsg_zynq_pl_simulation {
 
     void *allocate_dram(unsigned long len_in_bytes, unsigned long *physical_ptr) {
         bsg_pr_info("  bsg_zynq_pl: Allocated dummy DRAM\n");
-        return (void *)(physical_ptr = (unsigned long *)0xdeadbeef);
+        void *virtual_ptr = (unsigned long *)malloc(len_in_bytes);
+        *physical_ptr = (unsigned long)virtual_ptr;
+
+        return virtual_ptr;
     }
 
     void free_dram(void *virtual_ptr) {

--- a/cosim/include/xcelium/bsg_zynq_pl.h
+++ b/cosim/include/xcelium/bsg_zynq_pl.h
@@ -20,6 +20,7 @@
 #include "bsg_zynq_pl_simulation.h"
 
 extern "C" { void bsg_dpi_next(); }
+extern "C" { int bsg_dpi_time(); }
 
 class bsg_zynq_pl : public bsg_zynq_pl_simulation {
     public:

--- a/cosim/include/xcelium/bsg_zynq_pl.h
+++ b/cosim/include/xcelium/bsg_zynq_pl.h
@@ -41,7 +41,10 @@ class bsg_zynq_pl : public bsg_zynq_pl_simulation {
 
         void *allocate_dram(unsigned long len_in_bytes, unsigned long *physical_ptr) {
             bsg_pr_info("  bsg_zynq_pl: Allocated dummy DRAM\n");
-            return (void *)(physical_ptr = (unsigned long *)0xdeadbeef);
+            void *virtual_ptr = (unsigned long *)malloc(len_in_bytes);
+            *physical_ptr = (unsigned long)virtual_ptr;
+
+            return virtual_ptr;
         }
 
         void free_dram(void *virtual_ptr) {

--- a/cosim/include/zynq/bsg_zynq_pl.h
+++ b/cosim/include/zynq/bsg_zynq_pl.h
@@ -70,6 +70,14 @@ class bsg_zynq_pl : public bsg_zynq_pl_hardware {
             printf("bsg_zynq_pl: done() called, exiting\n");
         }
 
+	void start(void) override {
+
+	}
+
+	void stop(void) override {
+
+	}
+
         // returns virtual pointer, writes physical parameter into arguments
         void *allocate_dram(unsigned long len_in_bytes, unsigned long *physical_ptr) override {
 

--- a/cosim/manycore-example/Makefile.design
+++ b/cosim/manycore-example/Makefile.design
@@ -27,7 +27,7 @@ BSG_PLATFORM_PATH := $(LIBRARIES_PATH)/platforms/bigblade-vcs
 BSG_F1_DIR        := $(BSG_REPLICANT_DIR)
 include $(BSG_REPLICANT_DIR)/hardware/hardware.mk
 
-$(CURR_VSRC_DIR)/bsg_bladerunner_pkg.sv: $(BSG_MACHINE_PATH)/bsg_bladerunner_pkg.v
+$(CURR_VSRC_DIR)/bsg_bladerunner_pkg.sv: $(BSG_MACHINE_PATH)/bsg_bladerunner_pkg.sv
 	cp $< $@
 	$(SED) -i "/parameter int bsg_machine_hetero_type_vec_gp/d" $@
 

--- a/cosim/manycore-example/ps.cpp
+++ b/cosim/manycore-example/ps.cpp
@@ -137,7 +137,7 @@ int ps_main(int argc, char **argv) {
   buf = (volatile int32_t *)zpl->allocate_dram(allocated_dram, &phys_ptr);
   bsg_pr_info("ps.cpp: received %p (phys = %lx)\n", buf, phys_ptr);
   zpl->shell_write(GP0_WR_CSR_DRAM_BASE, phys_ptr, 0xf);
-  assert((zpl->shell_read(GP0_RD_CSR_DRAM_BASE) == phys_ptr));
+  assert((zpl->shell_read(GP0_RD_CSR_DRAM_BASE) == (int32_t)phys_ptr));
   bsg_pr_info("ps.cpp: wrote and verified base register\n");
 
   if (argc == 1) {

--- a/cosim/mk/Makefile.bridge
+++ b/cosim/mk/Makefile.bridge
@@ -5,7 +5,7 @@ CFLAGS += -DBRIDGE
 CFLAGS += -DHOST_$(call upper,$(HOST))
 CFLAGS += $(addprefix -D,$(DEFINES))
 CFLAGS += -O2
-CFLAGS += -std=c++14
+CFLAGS += -std=c++20
 
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/common
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/bridge

--- a/cosim/mk/Makefile.vcs
+++ b/cosim/mk/Makefile.vcs
@@ -12,7 +12,7 @@ VCS_OPTS += -diag timescale
 VCS_OPTS += -f flist.vcs
 VCS_OPTS += -top $(TB_MODULE)
 VCS_OPTS += -debug_pp
-VCS_OPTS += +vcs+vcdpluson +vcs+vcdplusautoflushon +vpdfilesize+64
+VCS_OPTS += +vcs+vcdpluson +vcs+vcdplusautoflushon
 VCS_OPTS += +vcs+lic+wait
 VCS_OPTS += +incdir+$(COSIM_DIR)/include/vcs
 VCS_OPTS += $(addprefix +define+,$(DEFINES))
@@ -23,7 +23,7 @@ VCS_OPTS += $(BP_SDK_LIB_DIR)/libboost_system.a
 
 CFLAGS += -DVCS
 CFLAGS += -DHOST_$(call upper,$(HOST))
-CFLAGS += -std=c++14
+CFLAGS += -std=c++20
 CFLAGS += $(addprefix -D,$(DEFINES))
 
 CINCLUDES += -I$(BP_SDK_INSTALL_DIR)/include

--- a/cosim/mk/Makefile.vcs
+++ b/cosim/mk/Makefile.vcs
@@ -24,6 +24,7 @@ VCS_OPTS += $(BP_SDK_LIB_DIR)/libboost_system.a
 CFLAGS += -DVCS
 CFLAGS += -DHOST_$(call upper,$(HOST))
 CFLAGS += -std=c++14
+CFLAGS += -D_DEFAULT_SOURCE -D_BSD_SOURCE
 CFLAGS += $(addprefix -D,$(DEFINES))
 
 CINCLUDES += -I$(BP_SDK_INSTALL_DIR)/include

--- a/cosim/mk/Makefile.vcs
+++ b/cosim/mk/Makefile.vcs
@@ -23,7 +23,7 @@ VCS_OPTS += $(BP_SDK_LIB_DIR)/libboost_system.a
 
 CFLAGS += -DVCS
 CFLAGS += -DHOST_$(call upper,$(HOST))
-CFLAGS += -std=c++20
+CFLAGS += -std=c++14
 CFLAGS += $(addprefix -D,$(DEFINES))
 
 CINCLUDES += -I$(BP_SDK_INSTALL_DIR)/include

--- a/cosim/mk/Makefile.verilator
+++ b/cosim/mk/Makefile.verilator
@@ -13,7 +13,7 @@ VV_OPTS += $(addprefix +define+,$(DEFINES))
 CFLAGS += -DVERILATOR
 CFLAGS += -DHOST_$(call upper,$(HOST))
 CFLAGS += $(addprefix -D,$(DEFINES))
-CFLAGS += -std=c++20
+CFLAGS += -std=c++14
 
 LDFLAGS += -L$(BP_SDK_INSTALL_DIR)/lib
 LDFLAGS += -lboost_coroutine -lboost_context -lboost_system

--- a/cosim/mk/Makefile.verilator
+++ b/cosim/mk/Makefile.verilator
@@ -13,7 +13,7 @@ VV_OPTS += $(addprefix +define+,$(DEFINES))
 CFLAGS += -DVERILATOR
 CFLAGS += -DHOST_$(call upper,$(HOST))
 CFLAGS += $(addprefix -D,$(DEFINES))
-CFLAGS += -std=c++14
+CFLAGS += -std=c++20
 
 LDFLAGS += -L$(BP_SDK_INSTALL_DIR)/lib
 LDFLAGS += -lboost_coroutine -lboost_context -lboost_system

--- a/cosim/mk/Makefile.zynq
+++ b/cosim/mk/Makefile.zynq
@@ -12,7 +12,7 @@ CFLAGS += -DHOST_$(call upper,$(HOST))
 CFLAGS += $(addprefix -D,$(DEFINES))
 CFLAGS += -O2
 CFLAGS += -lcma -lpthread
-CFLAGS += -std=c++14
+CFLAGS += -std=c++20
 
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/common
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/zynq

--- a/cosim/mk/Makefile.zynq
+++ b/cosim/mk/Makefile.zynq
@@ -12,7 +12,7 @@ CFLAGS += -DHOST_$(call upper,$(HOST))
 CFLAGS += $(addprefix -D,$(DEFINES))
 CFLAGS += -O2
 CFLAGS += -lcma -lpthread
-CFLAGS += -std=c++20
+CFLAGS += -std=c++14
 
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/common
 CINCLUDES += -I$(COSIM_INCLUDE_DIR)/zynq

--- a/cosim/uart-bridge-example/ps.cpp
+++ b/cosim/uart-bridge-example/ps.cpp
@@ -14,6 +14,9 @@
 
 #include "ps.hpp"
 
+
+#error "This example currently does not work, will be moved into shell example"
+
 int ps_main(int argc, char **argv) {
         bsg_zynq_pl *zpl = new bsg_zynq_pl(argc, argv);
 

--- a/cosim/uart-bridge-example/vcs/Makefile
+++ b/cosim/uart-bridge-example/vcs/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.design
 #############################
 # Accelerator Software Settings
 #############################
-#CFLAGS += -DZYNQ_PL_DEBUG
+CFLAGS += -DZYNQ_PL_DEBUG
 CFLAGS += -DZYNQ_PS_DEBUG
 
 DEFINES += HP1_ENABLE

--- a/cosim/v/bsg_nonsynth_zynq_testbench.sv
+++ b/cosim/v/bsg_nonsynth_zynq_testbench.sv
@@ -484,6 +484,11 @@ module bsg_nonsynth_zynq_testbench;
      @(posedge aclk);
      #1;
    endtask
+
+   export "DPI-C" function bsg_dpi_time;
+   function int bsg_dpi_time();
+     return $time;
+   endfunction
 `endif
 
 endmodule

--- a/cosim/v/bsg_nonsynth_zynq_testbench.sv
+++ b/cosim/v/bsg_nonsynth_zynq_testbench.sv
@@ -484,12 +484,12 @@ module bsg_nonsynth_zynq_testbench;
      @(posedge aclk);
      #1;
    endtask
+`endif
 
    export "DPI-C" function bsg_dpi_time;
    function int bsg_dpi_time();
      return $time;
    endfunction
-`endif
 
 endmodule
 

--- a/cosim/v/bsg_zynq_uart_bridge.sv
+++ b/cosim/v/bsg_zynq_uart_bridge.sv
@@ -99,8 +99,9 @@ module bsg_zynq_uart_bridge
   typedef struct packed
   {
     logic [31:0] data;
-    logic [6:0]  addr8to2;
+    logic [5:0]  addr7to2;
     logic        wr_not_rd;
+    logic        port;
   } bsg_uart_pkt_s;
 
   //
@@ -320,7 +321,7 @@ module bsg_zynq_uart_bridge
         e_req_send:
           begin
             gp0_wdata_li = uart_pkt_lo.data;
-            gp0_addr_li = (uart_pkt_lo.addr8to2 << 2'b10);
+            gp0_addr_li = (uart_pkt_lo.addr7to2 << 2'b10);
             gp0_v_li = uart_pkt_v_lo;
             gp0_w_li = uart_pkt_lo.wr_not_rd;
 


### PR DESCRIPTION
This PR fixes the coroutine flow, which currently has a deadlock condition. With the refactor, coroutines are spawned for each of the peripheral reads and writes. This allows for parallel execution of peripherals alongside shell reads. However, this change is hidden behind an unchanged API so users should not see any difference