### PR TITLE
Resolve UID/GID conflicts and add developer guidance

### DIFF
--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -53,15 +53,8 @@ RUN useradd --no-log-init --uid $USER_ID --gid $GROUP_ID --home-dir $WORKDIR $US
 
 # Add the user to other groups
 RUN for gid in ${OTHER_GROUPS}; do \
-		# Check if a group with this GID already exists in the container
-		# Then add user accordingly
-		EXISTING_NAME=$(getent group $gid | cut -d: -f1); \
-		if [ -n "$EXISTING_NAME" ]; then \
-			usermod -aG "$EXISTING_NAME" $USER_NAME; \
-		else \
-			groupadd -g $gid "group$gid" && \
-			usermod -aG "group$gid" $USER_NAME; \
-		fi; \
+		groupadd -g $gid "group$gid" || true; \
+		usermod -aG "$(getent group $gid)" "$USER_NAME"; \
     done
 
 # Create directory for extra installation

--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -53,9 +53,15 @@ RUN useradd --no-log-init --uid $USER_ID --gid $GROUP_ID --home-dir $WORKDIR $US
 
 # Add the user to other groups
 RUN for gid in ${OTHER_GROUPS}; do \
-        echo "group$gid"; \
-        groupadd -g $gid "group$gid" || true; \
-        usermod -aG "group$gid" $USER_NAME; \
+		# Check if a group with this GID already exists in the container
+		# Then add user accordingly
+		EXISTING_NAME=$(getent group $gid | cut -d: -f1); \
+		if [ -n "$EXISTING_NAME" ]; then \
+			usermod -aG "$EXISTING_NAME" $USER_NAME; \
+		else \
+			groupadd -g $gid "group$gid" && \
+			usermod -aG "group$gid" $USER_NAME; \
+		fi; \
     done
 
 # Create directory for extra installation

--- a/docker/Dockerfile.ubuntu24.04
+++ b/docker/Dockerfile.ubuntu24.04
@@ -33,6 +33,11 @@ ARG OTHER_GROUPS
 ARG WORKDIR=/work
 ENV DOCKERFILE_PLATFORM="ubuntu24.04"
 
+# Only delete the 'ubuntu' user if its UID (1000) matches the one we need to create
+RUN if [ "$USER_ID" = "1000" ]; then \
+		touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu || true; \
+	fi
+
 # Only create the group if it doesn't exist
 RUN getent group $GROUP_ID || groupadd --gid $GROUP_ID $GROUP_NAME
 
@@ -41,9 +46,15 @@ RUN useradd --no-log-init --uid $USER_ID --gid $GROUP_ID --home-dir $WORKDIR $US
 
 # Add the user to other groups
 RUN for gid in ${OTHER_GROUPS}; do \
-        echo "group$gid"; \
-        groupadd -g $gid "group$gid" || true; \
-        usermod -aG "group$gid" $USER_NAME; \
+		# Check if a group with this GID already exists in the container
+		# Then add user accordingly
+		EXISTING_NAME=$(getent group $gid | cut -d: -f1); \
+		if [ -n "$EXISTING_NAME" ]; then \
+			usermod -aG "$EXISTING_NAME" $USER_NAME; \
+		else \
+			groupadd -g $gid "group$gid" && \
+			usermod -aG "group$gid" $USER_NAME; \
+		fi; \
     done
 
 # Create directory for extra installation

--- a/docker/Dockerfile.ubuntu24.04
+++ b/docker/Dockerfile.ubuntu24.04
@@ -33,10 +33,8 @@ ARG OTHER_GROUPS
 ARG WORKDIR=/work
 ENV DOCKERFILE_PLATFORM="ubuntu24.04"
 
-# Only delete the 'ubuntu' user if its UID (1000) matches the one we need to create
-RUN if [ "$USER_ID" = "1000" ]; then \
-		touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu || true; \
-	fi
+# Delete default ubuntu user
+RUN userdel -r ubuntu || true;
 
 # Only create the group if it doesn't exist
 RUN getent group $GROUP_ID || groupadd --gid $GROUP_ID $GROUP_NAME
@@ -46,15 +44,8 @@ RUN useradd --no-log-init --uid $USER_ID --gid $GROUP_ID --home-dir $WORKDIR $US
 
 # Add the user to other groups
 RUN for gid in ${OTHER_GROUPS}; do \
-		# Check if a group with this GID already exists in the container
-		# Then add user accordingly
-		EXISTING_NAME=$(getent group $gid | cut -d: -f1); \
-		if [ -n "$EXISTING_NAME" ]; then \
-			usermod -aG "$EXISTING_NAME" $USER_NAME; \
-		else \
-			groupadd -g $gid "group$gid" && \
-			usermod -aG "group$gid" $USER_NAME; \
-		fi; \
+		groupadd -g $gid "group$gid" || true; \
+		usermod -aG "$(getent group $gid)" "$USER_NAME"; \
     done
 
 # Create directory for extra installation

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,8 +6,19 @@ USE_LOCAL_CREDENTIALS ?=
 
 # Supported platforms
 ALL_PLATFORMS := $(subst Dockerfile.,,$(wildcard Dockerfile.*))
+# Check if DOCKER_PLATFORM is empty
+ifeq ($(DOCKER_PLATFORM),)
+$(error DOCKER_PLATFORM is empty. Allowed values: $(ALL_PLATFORMS))
+endif
+# Check if DOCKER_PLATFORM is correct
 ifneq ($(filter $(DOCKER_PLATFORM),$(ALL_PLATFORMS)),$(DOCKER_PLATFORM))
-$(error DOCKER_PLATFORM "$(DOCKER_PLATFORM)" is invalid. Allowed values: $(ALL_PLATFORMS)")
+$(error DOCKER_PLATFORM "$(DOCKER_PLATFORM)" is invalid. Allowed values: $(ALL_PLATFORMS))
+endif
+
+# User Guidance
+ifeq ($(USE_LOCAL_CREDENTIALS),)
+$(warning [WARNING] Building/Running WITHOUT local credentials.)
+$(warning [WARNING] For local development, set USE_LOCAL_CREDENTIALS otherwise the content WON'T be mounted)
 endif
 
 docker-run: ## mounts as a docker container


### PR DESCRIPTION
- Fixes Ubuntu 24.04 build with set NO_LOCAL_CREDENTIALS failure by removing default 'ubuntu' user at UID 1000 (default user for local is 1000, so it's collide)
- Refactors group addition loop to dynamically resolve existing GIDs.
- Adds Makefile warnings to guide users on using USE_LOCAL_CREDENTIALS.