### PR TITLE
Hotfix the dockerfile group logic

### DIFF
--- a/docker/Dockerfile.centos7
+++ b/docker/Dockerfile.centos7
@@ -54,7 +54,7 @@ RUN useradd --no-log-init --uid $USER_ID --gid $GROUP_ID --home-dir $WORKDIR $US
 # Add the user to other groups
 RUN for gid in ${OTHER_GROUPS}; do \
 		groupadd -g $gid "group$gid" || true; \
-		usermod -aG "$(getent group $gid)" "$USER_NAME"; \
+		usermod -aG "$(getent group $gid | cut -d: -f1)" "$USER_NAME"; \
     done
 
 # Create directory for extra installation

--- a/docker/Dockerfile.ubuntu24.04
+++ b/docker/Dockerfile.ubuntu24.04
@@ -45,7 +45,7 @@ RUN useradd --no-log-init --uid $USER_ID --gid $GROUP_ID --home-dir $WORKDIR $US
 # Add the user to other groups
 RUN for gid in ${OTHER_GROUPS}; do \
 		groupadd -g $gid "group$gid" || true; \
-		usermod -aG "$(getent group $gid)" "$USER_NAME"; \
+		usermod -aG "$(getent group $gid | cut -d: -f1)" "$USER_NAME"; \
     done
 
 # Create directory for extra installation


### PR DESCRIPTION
From previous PR (https://github.com/black-parrot-hdk/zynq-parrot/pull/118) the group loop result in this error
```
 > [ 9/20] RUN for gid in 1000 90 964 968 985 986 994 998; do 		groupadd -g $gid "group$gid" || true; 		usermod -aG "$(getent group $gid)" "test";     done:
0.064 groupadd: GID '1000' already exists
0.069 usermod: group 'test:x:1000:' does not exist
0.084 usermod: group 'group90:x:90:' does not exist
0.098 usermod: group 'group964:x:964:' does not exist
0.110 usermod: group 'group968:x:968:' does not exist
0.122 usermod: group 'group985:x:985:' does not exist
0.135 usermod: group 'group986:x:986:' does not exist
0.150 usermod: group 'group994:x:994:' does not exist
0.151 groupadd: GID '998' already exists
0.153 usermod: group 'systemd-network:x:998:' does not exist
------
Dockerfile.ubuntu24.04:46
--------------------
  45 |     # Add the user to other groups
  46 | >>> RUN for gid in ${OTHER_GROUPS}; do \
  47 | >>> 		groupadd -g $gid "group$gid" || true; \
  48 | >>> 		usermod -aG "$(getent group $gid)" "$USER_NAME"; \
  49 | >>>     done
  50 |     
--------------------
```

Because `getent group $git` get the whole string (group994:x:994:). This PR refine the group assignment loop to correctly parse group names.